### PR TITLE
Build 32-bit version

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "skip-arches": ["aarch64", "arm", "i386"]
+  "skip-arches": ["aarch64", "arm"]
 }


### PR DESCRIPTION
64-bit version can't ever work on 32-bit distros. Can also be installed by users with special requirements on 64-bit systems but using 64-bit is highly recommended since it's multilib and can run both 32-bit and 64-bit games