### PR TITLE
Fdo runtime

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -29,9 +29,7 @@
         "--extension=org.freedesktop.Platform.GL32=add-ld-path=lib",
         "--extension=org.freedesktop.Platform.GL32=merge-dirs=vulkan/icd.d;glvnd/egl_vendor.d",
         "--extension=org.freedesktop.Platform.GL32=download-if=active-gl-driver",
-        "--extension=org.freedesktop.Platform.GL32=enable-if=active-gl-driver",
-        "--env=LD_LIBRARY_PATH=/app/lib:/app/lib/32bit/lib",
-        "--env=STEAM_RUNTIME_PREFER_HOST_LIBRARIES=0"
+        "--extension=org.freedesktop.Platform.GL32=enable-if=active-gl-driver"
     ],
     "build-options" : {
         "env": {
@@ -63,6 +61,10 @@
                         "sed -i s:/usr/bin/steam:/app/bin/steam-wrapper: steam.desktop",
                         "sed -i s:/usr/lib/:/app/lib/: steam"
                     ]
+                },
+                {
+                    "type": "file",
+                    "path": "ld.so.conf"
                 }
             ],
             "post-install": [
@@ -72,7 +74,8 @@
                 "mkdir -p /app/lib/32bit",
                 "ln -s /app/lib/32bit/lib/ld-linux.so.2 /app/lib/ld-linux.so.2",
                 "mkdir -p /app/share/appdata",
-                "cp com.valvesoftware.Steam.appdata.xml /app/share/appdata"
+                "cp com.valvesoftware.Steam.appdata.xml /app/share/appdata",
+                "install -Dm644 ld.so.conf /app/etc/ld.so.conf"
             ]
         }
     ]

--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -31,7 +31,6 @@
         "--extension=org.freedesktop.Platform.GL32=download-if=active-gl-driver",
         "--extension=org.freedesktop.Platform.GL32=enable-if=active-gl-driver",
         "--env=LD_LIBRARY_PATH=/app/lib:/app/lib/32bit/lib",
-        "--env=LIBGL_DRIVERS_PATH=/usr/lib/dri:/app/lib/32bit/lib/dri",
         "--env=STEAM_RUNTIME_PREFER_HOST_LIBRARIES=0"
     ],
     "build-options" : {

--- a/ld.so.conf
+++ b/ld.so.conf
@@ -1,0 +1,3 @@
+# We just make any GL32 extension have higher priority
+include /run/flatpak/ld.so.conf.d/app-*-org.freedesktop.Platform.GL32.*.conf
+/app/lib/32bit/lib

--- a/steam-wrapper
+++ b/steam-wrapper
@@ -2,6 +2,12 @@
 
 set -eu
 
+if ! [ -s /etc/ld.so.conf ]; then
+    # Fallback for flatpak < 0.9.99
+    export LD_LIBRARY_PATH=/app/lib:/app/lib/32bit/lib
+    export STEAM_RUNTIME_PREFER_HOST_LIBRARIES=0
+fi
+
 _STEAM_HOME="$HOME/.var/app/com.valvesoftware.Steam/home"
 if [ -d $_STEAM_HOME ]; then
     set -x


### PR DESCRIPTION
This PR depends on flatpak/freedesktop-sdk-images#51.

Flatpak 0.9.99 is required for using the fd.o runtime. Using flatpak < 0.9.99 should fallback to previous behavior.

Using fd.o runtime should help fix sound problem in various games using alsa-lib. It should make static linking to libstdc++ useless.