### PR TITLE
Add OARS metadata. This might be extreme but it's on all Steam.

### DIFF
--- a/com.valvesoftware.Steam.appdata.xml
+++ b/com.valvesoftware.Steam.appdata.xml
@@ -31,5 +31,34 @@
       <image type="source" width="1280" height="720">https://raw.githubusercontent.com/flathub/com.valvesoftware.Steam/master/com.valvesoftware.Steam.screenshot-2.png</image>
     </screenshot>
   </screenshots>
+    <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">intense</content_attribute>
+    <content_attribute id="violence-fantasy">intense</content_attribute>
+    <content_attribute id="violence-realistic">intense</content_attribute>
+    <content_attribute id="violence-bloodshed">intense</content_attribute>
+    <content_attribute id="violence-sexual">intense</content_attribute>
+    <content_attribute id="violence-desecration">intense</content_attribute>
+    <content_attribute id="violence-slavery">intense</content_attribute>
+    <content_attribute id="violence-worship">intense</content_attribute>
+    <content_attribute id="drugs-alcohol">moderate</content_attribute>
+    <content_attribute id="drugs-narcotics">moderate</content_attribute>
+    <content_attribute id="drugs-tobacco">moderate</content_attribute>
+    <content_attribute id="sex-nudity">intense</content_attribute>
+    <content_attribute id="sex-themes">intense</content_attribute>
+    <content_attribute id="sex-homosexuality">moderate</content_attribute>
+    <content_attribute id="sex-prostitution">moderate</content_attribute>
+    <content_attribute id="sex-adultery">moderate</content_attribute>
+    <content_attribute id="sex-appearance">intense</content_attribute>
+    <content_attribute id="language-profanity">intense</content_attribute>
+    <content_attribute id="language-humor">intense</content_attribute>
+    <content_attribute id="language-discrimination">intense</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">intense</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">intense</content_attribute>
+    <content_attribute id="money-gambling">intense</content_attribute>
+  </content_rating>
   <update_contact>tingping_AT_fedoraproject.org</update_contact>
 </application>


### PR DESCRIPTION
I noticed that #37 which added some excellent new appdata info didn't have OARS, so I quickly ran through the [new tool](https://hughsie.github.io/oars/). Steam contains examples of basically everything (as you might expect from the world's most comprehensive PC games store).

Patches and views welcome.