### PR TITLE
Use "--allow=devel" to allow some blacklisted syscalls inside the sandbox

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -18,6 +18,7 @@
         "--filesystem=xdg-music:ro",
         "--device=all",
         "--allow=multiarch",
+        "--allow=devel",
         "--persist=.",
         "--extension=org.freedesktop.Platform.Compat32=directory=lib/32bit",
         "--extension=org.freedesktop.Platform.Compat32=version=1.6",


### PR DESCRIPTION
This PR enables the `ptrace`, `personality` and `perf_event_open` syscalls inside the sandbox. While we're technically only interested in allowing the `ptrace` syscall for the purpose of solving #70, Flatpak doesn't currently allow granular whitelisting of syscalls, so this is our only option.

See #70 for more information.