### PR TITLE
Attempt to workaround #102

### DIFF
--- a/steam-wrapper
+++ b/steam-wrapper
@@ -17,5 +17,5 @@ if [ -d $_STEAM_HOME ]; then
     unset GLOBIGNORE
     set +x
 fi
-
+unset ALSA_CONFIG_PATH # https://github.com/flathub/com.valvesoftware.Steam/issues/102
 exec /app/bin/steam "$@"


### PR DESCRIPTION
Some distros set ALSA_CONFIG_PATH which apparently is leaked into Flatpak. Unset it in the Steam wrapper before running Steam