### PR TITLE
Another attempt to workaround #102

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -31,7 +31,8 @@
         "--extension=org.freedesktop.Platform.GL32=add-ld-path=lib",
         "--extension=org.freedesktop.Platform.GL32=merge-dirs=vulkan/icd.d;glvnd/egl_vendor.d",
         "--extension=org.freedesktop.Platform.GL32=download-if=active-gl-driver",
-        "--extension=org.freedesktop.Platform.GL32=enable-if=active-gl-driver"
+        "--extension=org.freedesktop.Platform.GL32=enable-if=active-gl-driver",
+        "--env=ALSA_CONFIG_PATH="
     ],
     "build-options" : {
         "env": {


### PR DESCRIPTION
Some distros set ALSA_CONFIG_PATH which apparently is leaked into Flatpak. Setting it as finish-args should allow setting it to something else through overrides