### PR TITLE
Revert "Allow bluetooth for Steam Controllers (#89)"

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -19,7 +19,6 @@
         "--device=all",
         "--allow=multiarch",
         "--allow=devel",
-        "--allow=bluetooth",
         "--persist=.",
         "--extension=org.freedesktop.Platform.Compat32=directory=lib/32bit",
         "--extension=org.freedesktop.Platform.Compat32=version=1.6",


### PR DESCRIPTION
Reverts flathub/com.valvesoftware.Steam#90
The bluetooth allow broke all the way until Flatpak 0.99.3 so I'm going to revert this, see https://github.com/flathub/com.valvesoftware.Steam/issues/114