### PR TITLE
Feature/bluetooth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 This Flatpak is still being improved so feel free to check out and update the [wiki](https://github.com/flathub/com.valvesoftware.Steam/wiki/Tested-Games) for games known to work.
+
+Minimum requirement Flatpak 0.10.3

--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -21,6 +21,7 @@
         "--allow=devel",
         "--allow=bluetooth",
         "--persist=.",
+        "--require-version=0.10.3",
         "--extension=org.freedesktop.Platform.Compat32=directory=lib/32bit",
         "--extension=org.freedesktop.Platform.Compat32=version=1.6",
         "--extension=org.freedesktop.Platform.GL32=directory=lib/32bit/lib/GL",

--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -19,6 +19,7 @@
         "--device=all",
         "--allow=multiarch",
         "--allow=devel",
+        "--allow=bluetooth",
         "--persist=.",
         "--extension=org.freedesktop.Platform.Compat32=directory=lib/32bit",
         "--extension=org.freedesktop.Platform.Compat32=version=1.6",


### PR DESCRIPTION
Reintroduce the bluetooth support, document minimum Flatpak version, require minimum Flatpak version
Documenting Flatpak requirement fixes https://github.com/flathub/com.valvesoftware.Steam/issues/114 while reintroducing bluetooth support fixes https://github.com/flathub/com.valvesoftware.Steam/issues/89