### PR TITLE
Copy over build instructions for xrandr from Lutris

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -40,6 +40,14 @@
         }
     },
     "modules": [
+	{
+	    "name": "xrandr",
+	    "sources": [{
+		"type": "archive",
+		"url": "https://xorg.freedesktop.org/archive/individual/app/xrandr-1.5.0.tar.bz2",
+		"sha256": "c1cfd4e1d4d708c031d60801e527abc9b6d34b85f2ffa2cadd21f75ff38151cd"
+	    }]
+	},
         {
             "name": "gyp",
             "buildsystem": "simple",


### PR DESCRIPTION
Some games (eg #121 ) apparently need xrandr to work so bundle it