### PR TITLE
Disable Mesa shader cache as crash workaround

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -35,7 +35,8 @@
         "--extension=org.freedesktop.Platform.GL32=merge-dirs=vulkan/icd.d;glvnd/egl_vendor.d",
         "--extension=org.freedesktop.Platform.GL32=download-if=active-gl-driver",
         "--extension=org.freedesktop.Platform.GL32=enable-if=active-gl-driver",
-        "--env=ALSA_CONFIG_PATH="
+        "--env=ALSA_CONFIG_PATH=",
+        "--env=MESA_GLSL_CACHE_DISABLE=true"
     ],
     "build-options" : {
         "env": {


### PR DESCRIPTION
Add workaround for #130 
Apparently at least with some AMD GPU's Mesa repeatedly generates shaders that when loaded from cache result in crashes. Disable shader cache completely until we have a better workaround.