### PR TITLE
Re-enable Mesa shader path and add a better workaround

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -35,8 +35,7 @@
         "--extension=org.freedesktop.Platform.GL32=merge-dirs=vulkan/icd.d;glvnd/egl_vendor.d",
         "--extension=org.freedesktop.Platform.GL32=download-if=active-gl-driver",
         "--extension=org.freedesktop.Platform.GL32=enable-if=active-gl-driver",
-        "--env=ALSA_CONFIG_PATH=",
-        "--env=MESA_GLSL_CACHE_DISABLE=true"
+        "--env=ALSA_CONFIG_PATH="
     ],
     "build-options" : {
         "env": {

--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -10,6 +10,14 @@ import subprocess
 STEAM_PATH = "/app/bin/steam"
 STEAM_ROOT = os.path.expandvars("$HOME/.var/app/com.valvesoftware.Steam")
 
+def mesa_shader_workaround():
+    fallback = os.path.expandvars("$XDG_CACHE_HOME/mesa_shader_cache")
+    path = os.environ.get("MESA_GLSL_CACHE_DIR", fallback)
+    if os.path.isdir(path):
+        print (f"Flushing {path}")
+        shutil.rmtree(path)
+
+
 def prompt():
     p = subprocess.Popen(["zenity", "--question",
                           ("--text="
@@ -140,4 +148,5 @@ def main():
     if consent:
         migrate_data()
         migrate_shared()
+    mesa_shader_workaround()
     os.execve(STEAM_PATH, [STEAM_PATH] + sys.argv[1:], os.environ)


### PR DESCRIPTION
Conserning #130 ; shader cache is now enabled but flushed when Steam is first started. Proper detection logic for whether cache should be flushed to be done later