### PR TITLE
Use Freedesktop Sdk for the Runtime

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -1,6 +1,6 @@
 {
     "app-id": "com.valvesoftware.Steam",
-    "runtime": "org.freedesktop.Platform",
+    "runtime": "org.freedesktop.Sdk",
     "runtime-version": "18.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "steam-wrapper",


### PR DESCRIPTION
With the launch of Steam Play Proton, Steam has a dependency again
on Python2. Having to change from .Platform to .Sdk is painful,
but here are couple points about doing it:

* I could not find a recipe for bundling python2 quickly and Steam
is one of the most popular Flatpaks

* I am not sure if Photon introduced any other dependencies with
all the DX to Vulkan translation stuff it does

* Bundling python2 can be a security risk and increases maintenance,
so Its probably better to reuse the one from the .Sdk.