### PR TITLE
Override consent to false again

### DIFF
--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -154,7 +154,7 @@ def migrate_config():
     relocated = os.path.expandvars("$XDG_CONFIG_HOME.old")
     if not os.path.islink(source):
         if os.path.isdir(target):
-            consent = prompt()
+            consent = False
             if not consent:
                 return consent
         copytree(source, target)


### PR DESCRIPTION
Realized that *if* Flatpak was to ever point XDG_CONFIG_HOME to .config, the migration would delete basically everything
Ping @TingPing 