### PR TITLE
Ensure steam-wrapper starts in $HOME

### DIFF
--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -220,6 +220,7 @@ def repair_broken_migration():
         shutil.rmtree(wrong_data)
 
 def main():
+    os.chdir(os.environ["HOME"]) # Ensure sane cwd
     legacy_support()
     consent = migrate_config()
     if consent:


### PR DESCRIPTION
Flatpak has interesting logic where it preserves cwd if host path
is available in the guest. chdir to home to make sure this is never
applied. Fixes #155 