### PR TITLE
Add lightweight terminal emulator

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -68,6 +68,57 @@
 		"sha256": "c1cfd4e1d4d708c031d60801e527abc9b6d34b85f2ffa2cadd21f75ff38151cd"
 	    }]
 	},
+        {
+            "name": "xterm",
+            "build-options": {
+                "ldflags": "-ltinfo"
+            },
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "ftp://ftp.invisible-island.net/xterm/xterm-335.tgz",
+                    "sha256": "e0bf172a9bf301bd9d5ae27957f4f54687b5d22382fd2f4d872d0a4db47fcb96"
+                }
+            ],
+            "modules": [
+                {
+                    "name": "libxaw",
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "https://xorg.freedesktop.org/releases/individual/lib/libXaw-1.0.13.tar.gz",
+                            "sha256": "7e74ac3e5f67def549722ff0333d6e6276b8becd9d89615cda011e71238ab694"
+                        }
+                    ],
+                    "cleanup": [
+                        "/lib/*.a",
+                        "/lib/*.la",
+                        "/include",
+                        "/lib/pkgconfig",
+                        "/share/doc"
+                    ],
+                    "modules": [
+                        {
+                            "name": "libxmu",
+                            "sources": [
+                                {
+                                    "type": "archive",
+                                    "url": "https://xorg.freedesktop.org/releases/individual/lib/libXmu-1.1.2.tar.gz",
+                                    "sha256": "e5fd4bacef068f9509b8226017205040e38d3fba8d2de55037200e7176c13dba"
+                                }
+                            ],
+                            "cleanup": [
+                                "/lib/*.a",
+                                "/lib/*.la",
+                                "/include",
+                                "/lib/pkgconfig",
+                                "/share/doc"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
 	{
 	    "name": "steam_wrapper",
 	    "buildsystem": "simple",


### PR DESCRIPTION
Currently, inspecting a game's console output requires running game's binary directly, with library path pointing to steam runtime, from flatpak app shell, which is way too complicated.
Adding a terminal emulator could help with this a lot, as it makes possible to run game in a terminal window just by setting game's launch options to something like `xterm -e "%command%"` via game settings.
Xterm is obvious choice, but maybe not the best.