### PR TITLE
Add Feral GameMode as module

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -139,9 +139,9 @@
 	        "-Dwith-examples=false"
 	    ],
 	    "sources": [{
-	        "type": "git",
-	        "url": "https://github.com/FeralInteractive/gamemode.git",
-	        "tag": "1.2"
+	        "type": "archive",
+	        "url": "https://github.com/FeralInteractive/gamemode/releases/download/1.2/gamemode-1.2.tar.xz",
+	        "sha256": "a7b8d63ffdcbea0dc8b557fda42a9471fa9ab0961a5450d2a15cccca0aaf6a95"
 	    }]
 	},
 	{

--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -15,6 +15,7 @@
         "--talk-name=org.gnome.SettingsDaemon",
         "--talk-name=org.freedesktop.NetworkManager",
         "--talk-name=org.kde.StatusNotifierWatcher",
+        "--talk-name=com.feralinteractive.GameMode",
         "--filesystem=xdg-music:ro",
         "--filesystem=xdg-pictures:ro",
         "--device=all",
@@ -129,6 +130,20 @@
                 "/share/pkgconfig"
             ]
         },
+	{
+	    "name": "gamemode",
+	    "buildsystem": "meson",
+	    "config-opts": [
+	        "-Dwith-systemd=false",
+	        "-Dwith-daemon=false",
+	        "-Dwith-examples=false"
+	    ],
+	    "sources": [{
+	        "type": "git",
+	        "url": "https://github.com/FeralInteractive/gamemode.git",
+	        "tag": "1.2"
+	    }]
+	},
 	{
 	    "name": "steam_wrapper",
 	    "buildsystem": "simple",


### PR DESCRIPTION
Per https://github.com/flathub/com.valvesoftware.Steam/issues/77.

This adds GameMode version 1.2 as a module. **It doesn't build yet** because
it requires libsystemd headers that are not available. GameMode requires libsystemd (it's not optional), particularly systemd/sd-bus.h header. See https://github.com/FeralInteractive/gamemode/issues/15.

You can get this build a bit further by changing line 39 on meson.build to have required: false (with a patch for example) but it will still fail when building. I also think it uses libsystemd to communicate which means that the library needs to be present.