### PR TITLE
Apply workaround for formatting errors

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -36,6 +36,7 @@
         "--extension=org.freedesktop.Platform.GL32=merge-dirs=vulkan/icd.d;glvnd/egl_vendor.d",
         "--extension=org.freedesktop.Platform.GL32=download-if=active-gl-driver",
         "--extension=org.freedesktop.Platform.GL32=enable-if=active-gl-driver",
+        "--env=LC_NUMERIC=C",
         "--env=ALSA_CONFIG_PATH=",
         "--env=MESA_GLSL_CACHE_DIR="
     ],


### PR DESCRIPTION
Investigations in #62 revealed differences in LC_NUMERIC may result in crashes. Force it to be C (generic). Downside is numbers may look non-native but that's not a very high price to pay. 
Can be disabled through flatpak override --env=LC_NUMERIC= com.valvesoftware.Steam