### PR TITLE
Remove unrestricted system bus access

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -16,6 +16,7 @@
         "--talk-name=org.freedesktop.NetworkManager",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--talk-name=com.feralinteractive.GameMode",
+        "--system-talk-name=org.freedesktop.UPower",
         "--filesystem=xdg-music:ro",
         "--filesystem=xdg-pictures:ro",
         "--device=all",

--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -10,7 +10,6 @@
     "finish-args": [
         "--share=ipc", "--socket=x11",
         "--socket=pulseaudio",
-        "--socket=system-bus",
         "--share=network",
         "--talk-name=org.gnome.SettingsDaemon",        
         "--talk-name=org.gnome.SettingsDaemon.MediaKeys",


### PR DESCRIPTION
As noted in #188, just removing this. Regressions will be handled individually (more explicit accesses may be required)