### PR TITLE
Bugfix/legacy support

### DIFF
--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -136,7 +136,6 @@ def legacy_support():
     if force_legacy or not check_nonempty("/etc/ld.so.conf"):
         # Fallback for flatpak < 0.9.99
         os.environ["LD_LIBRARY_PATH"] = "/app/lib:/app/lib/i386-linux-gnu"
-        os.environ["STEAM_RUNTIME_PREFER_HOST_LIBRARIES"] = "0"
 
     steam_home = os.path.expandvars("$HOME/.var/app/com.valvesoftware.Steam/home")
     if os.path.isdir(steam_home):

--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -132,7 +132,8 @@ def check_nonempty(name):
             return False
 
 def legacy_support():
-    if not check_nonempty("/etc/ld.so.conf"):
+    force_legacy = os.environ.get("FLATPAK_STEAM_LEGACY_MODE")
+    if force_legacy or not check_nonempty("/etc/ld.so.conf"):
         # Fallback for flatpak < 0.9.99
         os.environ["LD_LIBRARY_PATH"] = "/app/lib:/app/lib/i386-linux-gnu"
         os.environ["STEAM_RUNTIME_PREFER_HOST_LIBRARIES"] = "0"


### PR DESCRIPTION
Looks like after migration to Freedesktop runtime 18.08 the legacy path leads into errors like in #203; remove STEAM_RUNTIME_PREFER_HOST_LIBRARIES seems to make the issues go away. This should fix #203 