### PR TITLE
Feature/bluetooth

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,6 @@ works and what does not.
 If you're having issues, first see
 [frequently asked questions](https://github.com/flathub/com.valvesoftware.Steam/wiki/Frequently-asked-questions)
 to see if you're hitting some corner-case that needs manual intervention. If your case isn't listed, file an issue in addition to adding an entry in tested games.
+
+Minimum requirement Flatpak 0.10.3
+

--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ If you're having issues, first see
 [frequently asked questions](https://github.com/flathub/com.valvesoftware.Steam/wiki/Frequently-asked-questions)
 to see if you're hitting some corner-case that needs manual intervention. If your case isn't listed, file an issue in addition to adding an entry in tested games.
 
-Minimum requirement Flatpak 0.10.3
+Minimum requirement Flatpak 0.10.3. Recommended 1.0.0 or higher
 

--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -28,7 +28,7 @@
         "--env=LC_NUMERIC=C",
         "--env=ALSA_CONFIG_PATH=",
         "--env=MESA_GLSL_CACHE_DIR=",
-	"--require-version=0.10.3"
+        "--require-version=0.10.3"
     ],
     "add-extensions": {
         "org.freedesktop.Platform.Compat.i386": {

--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -27,8 +27,8 @@
         "--persist=.",
         "--env=LC_NUMERIC=C",
         "--env=ALSA_CONFIG_PATH=",
-        "--env=MESA_GLSL_CACHE_DIR="
-	"--require-version=0.10.3",
+        "--env=MESA_GLSL_CACHE_DIR=",
+	"--require-version=0.10.3"
     ],
     "add-extensions": {
         "org.freedesktop.Platform.Compat.i386": {

--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -23,6 +23,7 @@
         "--device=all",
         "--allow=multiarch",
         "--allow=devel",
+        "--allow=bluetooth",
         "--persist=.",
         "--env=LC_NUMERIC=C",
         "--env=ALSA_CONFIG_PATH=",

--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -28,6 +28,7 @@
         "--env=LC_NUMERIC=C",
         "--env=ALSA_CONFIG_PATH=",
         "--env=MESA_GLSL_CACHE_DIR="
+	"--require-version=0.10.3",
     ],
     "add-extensions": {
         "org.freedesktop.Platform.Compat.i386": {

--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -26,10 +26,10 @@ def read_flatpak_info(path):
     with open(path) as f:
         flatpak_info.read_file(f)
     return {
-        "flatpak-version": flatpak_info.get("Instance", "flatpak-version")
-        "runtime-path": flatpak_info.get("Instance", "runtime-path")
-        "app-extensions": flatpak_info.get("Instance", "app-extensions")
-        "runtime-extensions": flatpak_info.get("Instance", "runtime-extensions")
+        "flatpak-version": flatpak_info.get("Instance", "flatpak-version"),
+        "runtime-path": flatpak_info.get("Instance", "runtime-path"),
+        "app-extensions": flatpak_info.get("Instance", "app-extensions"),
+        "runtime-extensions": flatpak_info.get("Instance", "runtime-extensions"),
     }
 
 def flush_mesa_cache():
@@ -43,7 +43,7 @@ def flush_mesa_cache():
 
 def mesa_shader_workaround():
     current = os.path.expandvars("$XDG_CONFIG_HOME/.flatpak-info")
-    if not os.path.isfile(candidate):
+    if not os.path.isfile(FLATPAK_INFO):
         flush_mesa_cache()
     else:
         current_info = read_flatpak_info(FLATPAK_INFO)

--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -8,6 +8,7 @@ import fnmatch
 import subprocess
 import glob
 import configparser
+from distutils.version import StrictVersion
 
 
 STEAM_PATH = "/app/bin/steam"
@@ -133,9 +134,10 @@ def check_nonempty(name):
 
 def legacy_support():
     current_info = read_flatpak_info(FLATPAK_INFO)
-    version = tuple(int(x) for x in current_info["flatpak-version"].split("."))
-    if version < (0, 10, 3):
-        raise SystemExit("Flatpak 0.10.3 or newer required")
+    current_version = current_info["flatpak-version"]
+    required = "0.10.3"
+    if StrictVersion(current_version) < StrictVersion(required):
+        raise SystemExit(f"Flatpak {required} or newer required")
     steam_home = os.path.expandvars("$HOME/.var/app/com.valvesoftware.Steam/home")
     if os.path.isdir(steam_home):
         # Relocate from old migration


### PR DESCRIPTION
Require Flatpak 0.10.3
Verified distributions:
Debian 9 (mitigated through backports, will be fine after Debian 10)
Solus (ok)
Mageia (ok)
CentOS 7 (amigadave COPR can be used for now)

All in all there will be affected users but it's most likely simpler to help upgrading Flatpak than to debug esoteric issues with pre-0.9.99.