### PR TITLE
Mask TZ

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -24,6 +24,7 @@
         "--allow=multiarch",
         "--allow=devel",
         "--persist=.",
+        "--env=TZ=",
         "--env=LC_NUMERIC=C",
         "--env=ALSA_CONFIG_PATH=",
         "--env=MESA_GLSL_CACHE_DIR="


### PR DESCRIPTION
See #214, supporting TZ fully might be reasonably complex given the semantics of it so for now just don't let the host TZ leak into application context without an explicit override. This should make the TZ workaround be used for everyone unless there's an override.