### PR TITLE
Install time and runtime requirement of Flatpak 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ works and what does not.
 If you're having issues, first see
 [frequently asked questions](https://github.com/flathub/com.valvesoftware.Steam/wiki/Frequently-asked-questions)
 to see if you're hitting some corner-case that needs manual intervention. If your case isn't listed, file an issue in addition to adding an entry in tested games.
+
+Minimum version required 0.9.0

--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -27,7 +27,8 @@
         "--env=TZ=",
         "--env=LC_NUMERIC=C",
         "--env=ALSA_CONFIG_PATH=",
-        "--env=MESA_GLSL_CACHE_DIR="
+        "--env=MESA_GLSL_CACHE_DIR=",
+        "--require-version=0.9.0"
     ],
     "add-extensions": {
         "org.freedesktop.Platform.Compat.i386": {

--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -8,6 +8,7 @@ import fnmatch
 import subprocess
 import glob
 import configparser
+from distutils.version import StrictVersion
 
 
 STEAM_PATH = "/app/bin/steam"
@@ -17,19 +18,18 @@ XDG_CACHE_HOME = os.environ["XDG_CACHE_HOME"]
 CONFIG = ".config"
 DATA = ".local/share"
 CACHE = ".cache"
+FLATPAK_INFO = "/.flatpak-info"
 
 
 def read_flatpak_info(path):
     flatpak_info = configparser.ConfigParser()
-    flatpak_info.read(path)
+    with open(path) as f:
+        flatpak_info.read_file(f)
     return {
-        "runtime-path": flatpak_info.get("Instance", "runtime-path",
-                                         fallback=None),
-        "app-extensions": flatpak_info.get("Instance", "app-extensions",
-                                           fallback=None),
-        "runtime-extensions": flatpak_info.get("Instance",
-                                               "runtime-extensions",
-                                               fallback=None)
+        "flatpak-version": flatpak_info.get("Instance", "flatpak-version"),
+        "runtime-path": flatpak_info.get("Instance", "runtime-path"),
+        "app-extensions": flatpak_info.get("Instance", "app-extensions"),
+        "runtime-extensions": flatpak_info.get("Instance", "runtime-extensions")
     }
 
 def flush_mesa_cache():
@@ -43,12 +43,11 @@ def flush_mesa_cache():
 
 def mesa_shader_workaround():
     current = os.path.expandvars("$XDG_CONFIG_HOME/.flatpak-info")
-    candidate = "/.flatpak-info"
-    if not os.path.isfile(candidate):
+    if not os.path.isfile(FLATPAK_INFO):
         flush_mesa_cache()
-    elif read_flatpak_info(current) != read_flatpak_info(candidate):
+    elif read_flatpak_info(current) != read_flatpak_info(FLATPAK_INFO):
         flush_mesa_cache()
-        shutil.copy2(candidate, current)
+        shutil.copy2(FLATPAK_INFO, current)
 
 def read_file(path):
     try:
@@ -132,6 +131,12 @@ def check_nonempty(name):
             return False
 
 def legacy_support():
+    current_info = read_flatpak_info(FLATPAK_INFO)
+    current_version = current_info["flatpak-version"]
+    required = "0.9.0"
+    if StrictVersion(current_version) < StrictVersion(required):
+        raise SystemExit(f"Flatpak {required} or newer required")    
+    
     if not check_nonempty("/etc/ld.so.conf"):
         # Fallback for flatpak < 0.9.99
         os.environ["LD_LIBRARY_PATH"] = "/app/lib:/app/lib/i386-linux-gnu"

--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -28,8 +28,11 @@ def read_flatpak_info(path):
     return {
         "flatpak-version": flatpak_info.get("Instance", "flatpak-version"),
         "runtime-path": flatpak_info.get("Instance", "runtime-path"),
-        "app-extensions": flatpak_info.get("Instance", "app-extensions"),
-        "runtime-extensions": flatpak_info.get("Instance", "runtime-extensions")
+        "app-extensions": flatpak_info.get("Instance", "app-extensions",
+                                           fallback=None),
+        "runtime-extensions": flatpak_info.get("Instance",
+                                               "runtime-extensions",
+                                               fallback=None)
     }
 
 def flush_mesa_cache():


### PR DESCRIPTION
Require Flatpak 0.9.0
Verified distributions:
Debian 9 (mitigated through backports, will be fine after Debian 10)
Solus (ok)
Mageia (ok)
CentOS 7 (amigadave COPR can be used for now)

Closes #212 