### PR TITLE
Revert "Python 2 was only added for Proton. It should now no longer be needed"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -54,6 +54,7 @@
         }
     },
     "modules": [
+        "shared-modules/python2.7/python-2.7.15.json",
         {
             "name": "libnotify",
             "cleanup": ["/include", "/lib/*.la", "/lib/pkgconfig", "/share/doc/libnotify"],


### PR DESCRIPTION
Reverts flathub/com.valvesoftware.Steam#210
The fixed build is still pending in beta...
Fixes #225 