### PR TITLE
Unset STEAM_RUNTIME_PREFER_HOST_LIBRARIES

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -28,6 +28,7 @@
         "--env=LC_NUMERIC=C",
         "--env=ALSA_CONFIG_PATH=",
         "--env=MESA_GLSL_CACHE_DIR=",
+        "--env=STEAM_RUNTIME_PREFER_HOST_LIBRARIES=",  
         "--require-version=0.9.0"
     ],
     "add-extensions": {


### PR DESCRIPTION
Prevent STEAM_RUNTIME_PREFER_HOST_LIBRARIES from leaking from host without overrides. This makes sure everyone gets as consistent environment as possible.