### PR TITLE
Prevent STEAM_RUNTIME settings leaking

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -28,7 +28,8 @@
         "--env=LC_NUMERIC=C",
         "--env=ALSA_CONFIG_PATH=",
         "--env=MESA_GLSL_CACHE_DIR=",
-        "--env=STEAM_RUNTIME_PREFER_HOST_LIBRARIES=",  
+        "--env=STEAM_RUNTIME_PREFER_HOST_LIBRARIES=",
+        "--env=STEAM_RUNTIME=",
         "--require-version=0.9.0"
     ],
     "add-extensions": {


### PR DESCRIPTION
This is another variable that can make deployment environments accidentally heterogenous