### PR TITLE
"strip-components" should be integer

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -141,7 +141,7 @@
                 {
                     "type": "patch",
                     "path": "0001-meson-rename-Ddebug-to-Ddebug-extra.patch",
-                    "strip-components": "1"
+                    "strip-components": 1
                 }
             ],
             "cleanup": [


### PR DESCRIPTION
Otherwise, flatpak-builder says
```
(flatpak-builder:16077): Json-WARNING **: 21:19:19.515: Failed to deserialize "strip-components" property of type "guint" for an object of type "BuilderSourcePatch"
```