### PR TITLE
Clean up more thoroughly

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -58,10 +58,20 @@
             "enable-if": "active-gl-driver"
         }
     },
+    "cleanup": [
+        "/lib/*.a",
+        "/lib/*.la",
+        "/include",
+        "/lib/pkgconfig",
+        "/share/pkgconfig",
+        "/lib/cmake",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man"
+    ],
     "modules": [
         {
             "name": "libnotify",
-            "cleanup": ["/include", "/lib/*.la", "/lib/pkgconfig", "/share/doc/libnotify"],
             "config-opts": [
                 "--disable-static",
                 "--disable-tests",
@@ -151,10 +161,7 @@
                 "/lib/udev/rules.d",
                 "/lib/modprobe.d",
                 "/lib/kernel",
-                "/share/polkit-1",
-                "/include",
-                "/lib/pkgconfig",
-                "/share/pkgconfig"
+                "/share/polkit-1"
             ]
         },
         {

--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -156,12 +156,16 @@
             ],
             "cleanup": [
                 "/bin",
+                "/etc",
                 "/lib/systemd",
                 "/lib/sysctl.d",
                 "/lib/udev/rules.d",
                 "/lib/modprobe.d",
                 "/lib/kernel",
-                "/share/polkit-1"
+                "/lib/rpm",
+                "/share/polkit-1",
+                "/share/dbus-1",
+                "/share/factory"
             ]
         },
         {


### PR DESCRIPTION
Currently, the bundle has many unneeded files from it's modules, including static libs, headers, man pages and so on.
Adding a top-level cleanup entry will fix that, without the need to clean each module individually.