### PR TITLE
Make emitting warnings never exit process

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -33,6 +33,7 @@
         "--env=STEAM_RUNTIME_PREFER_HOST_LIBRARIES=",
         "--env=STEAM_RUNTIME=",
         "--env=SDL_VIDEODRIVER=",
+        "--env=DBUS_FATAL_WARNINGS=0",
         "--require-version=0.9.0"
     ],
     "add-extensions": {


### PR DESCRIPTION
See #252. Apparently Debian and Ubuntu carried a patch which
disabled assert in dbus_warn_check_failed. Now many older
games carry a bug that they call the wrong dbus function
because developers never realized they were. Add workaround
so the call is not fatal under this app by default. It can
made fatal again through a Flatpak override if needed.