### PR TITLE
Update Steam to 1.0.0.59

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -215,8 +215,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://repo.steampowered.com/steam/archive/precise/steam_latest.tar.gz",
-                    "sha256": "da15bb347bd286c3a8818c3c910dc5bdbc43a744604d5372260ec79540ba4f06"
+                    "url": "http://repo.steampowered.com/steam/archive/precise/steam_1.0.0.59.tar.gz",
+                    "sha256": "a5080db949793fc4eb543293a95a24131441a96ccc8f5deebdecd7257cfcd99f"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
Current checksum is outdated.
It's better to use versioned archive url, as `steam_latest.tar.gz` is expected to change.