### PR TITLE
Python bytecode generation

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -71,6 +71,9 @@
         "/share/gtk-doc",
         "/share/man"
     ],
+    "cleanup-commands": [
+	"python3 -m compileall --invalidation-mode=unchecked-hash /app"
+    ],
     "modules": [
         {
             "name": "libnotify",


### PR DESCRIPTION
Normally flatpak-builder removes Python bytecode. Regenerate hashed bytecode at the end.