### PR TITLE
Allow access to ScreenSaver and PowerManagement

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -20,6 +20,8 @@ finish-args:
   - --system-talk-name=org.freedesktop.NetworkManager
   - --talk-name=org.kde.StatusNotifierWatcher
   - --system-talk-name=org.freedesktop.UPower
+  - --talk-name=org.freedesktop.ScreenSaver
+  - --talk-name=org.freedesktop.PowerManagement
   - --filesystem=xdg-music:ro
   - --filesystem=xdg-pictures:ro
   - --device=all


### PR DESCRIPTION
 Addresses the warnings:
 ```
[0103/040648.596401:ERROR:object_proxy.cc(616)] Failed to call method: org.freedesktop.ScreenSaver.Inhibit: object_path= /org/freedesktop/ScreenSaver: org.freedesktop.DBus.Error.ServiceUnknown: org.freedesktop.DBus.Error.ServiceUnknown
[0103/040648.596475:ERROR:power_save_blocker_x11.cc(330)] No response to Inhibit() request!
[0103/040648.596589:ERROR:object_proxy.cc(616)] Failed to call method: org.freedesktop.PowerManagement.Inhibit.Inhibit: object_path= /org/freedesktop/PowerManagement/Inhibit: org.freedesktop.DBus.Error.ServiceUnknown: org.freedesktop.DBus.Error.ServiceUnknown
[0103/040648.596603:ERROR:power_save_blocker_x11.cc(330)] No response to Inhibit() request!
Installing breakpad exception handler for appid(steam)/version(1543346820)
[0103/040650.152625:ERROR:object_proxy.cc(616)] Failed to call method: org.freedesktop.ScreenSaver.UnInhibit: object_path= /org/freedesktop/ScreenSaver: org.freedesktop.DBus.Error.ServiceUnknown: org.freedesktop.DBus.Error.ServiceUnknown
[0103/040650.152656:ERROR:power_save_blocker_x11.cc(403)] No response to Uninhibit() request!
[0103/040650.152796:ERROR:object_proxy.cc(616)] Failed to call method: org.freedesktop.PowerManagement.Inhibit.UnInhibit: object_path= /org/freedesktop/PowerManagement/Inhibit: org.freedesktop.DBus.Error.ServiceUnknown: org.freedesktop.DBus.Error.ServiceUnknown
[0103/040650.152808:ERROR:power_save_blocker_x11.cc(403)] No response to Uninhibit() request!
[0103/040654.401650:ERROR:object_proxy.cc(616)] Failed to call method: org.freedesktop.ScreenSaver.Inhibit: object_path= /org/freedesktop/ScreenSaver: org.freedesktop.DBus.Error.ServiceUnknown: org.freedesktop.DBus.Error.ServiceUnknown
[0103/040654.401681:ERROR:power_save_blocker_x11.cc(330)] No response to Inhibit() request!
[0103/040654.401743:ERROR:object_proxy.cc(616)] Failed to call method: org.freedesktop.PowerManagement.Inhibit.Inhibit: object_path= /org/freedesktop/PowerManagement/Inhibit: org.freedesktop.DBus.Error.ServiceUnknown: org.freedesktop.DBus.Error.ServiceUnknown
[0103/040654.401754:ERROR:power_save_blocker_x11.cc(330)] No response to Inhibit() request!
[0103/040655.208524:ERROR:object_proxy.cc(616)] Failed to call method: org.freedesktop.ScreenSaver.UnInhibit: object_path= /org/freedesktop/ScreenSaver: org.freedesktop.DBus.Error.ServiceUnknown: org.freedesktop.DBus.Error.ServiceUnknown
[0103/040655.208554:ERROR:power_save_blocker_x11.cc(403)] No response to Uninhibit() request!
[0103/040655.208689:ERROR:object_proxy.cc(616)] Failed to call method: org.freedesktop.PowerManagement.Inhibit.UnInhibit: object_path= /org/freedesktop/PowerManagement/Inhibit: org.freedesktop.DBus.Error.ServiceUnknown: org.freedesktop.DBus.Error.ServiceUnknown
[0103/040655.208702:ERROR:power_save_blocker_x11.cc(403)] No response to Uninhibit() request!

```