### PR TITLE
Start integrating the new audit library

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -216,6 +216,7 @@ modules:
         mkdir -p /app/lib/i386-linux-gnu /app/lib/debug/lib/i386-linux-gnu
         install -Dm644 -t /app/share/metainfo com.valvesoftware.Steam.appdata.xml
         install -Dm644 -t /app/etc ld.so.conf
+        install -Dm644 -t /app/etc freedesktop.ld.so.blockedlist
     sources:
       - type: archive
         url: http://repo.steampowered.com/steam/archive/precise/steam_latest.tar.gz
@@ -224,6 +225,8 @@ modules:
         path: com.valvesoftware.Steam.appdata.xml
       - type: file
         path: ld.so.conf
+      - type: file
+        path: freedesktop.ld.so.blockedlist
 
   - name: steamcmd
     build-options:

--- a/freedesktop.ld.so.blockedlist
+++ b/freedesktop.ld.so.blockedlist
@@ -1,0 +1,1 @@
+Torchlight\ II/ModLauncher.bin.x86_64 Torchlight\ II/lib/libfontconfig.so.1

--- a/freedesktop.ld.so.blockedlist
+++ b/freedesktop.ld.so.blockedlist
@@ -1,1 +1,3 @@
 Torchlight\ II/ModLauncher.bin.x86_64 Torchlight\ II/lib/libfontconfig.so.1
+The\ Stanley\ Parable/bin/stanley_linux The\ Stanley\ Parable/bin/libSDL2-2.0.so.0
+The\ Stanley\ Parable/bin/stanley_linux The\ Stanley\ Parable/bin/libstdc++.so.6

--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -227,6 +227,17 @@ def repair_broken_migration():
         os.symlink(data, XDG_DATA_HOME)
         shutil.rmtree(wrong_data)
 
+def configure_shared_library_guard():
+    mode = int(os.environ.get("SHARED_LIBRARY_GUARD", 0))
+    if not mode:
+        return
+    else:
+        library = "libshared-library-guard.so"
+        os.environ["LD_AUDIT"] = os.pathsep.join((f"/usr/lib/x86-64-linux-gnu/{library}",
+                                                  f"/app/lib/i386-linux-gnu/{library}"))
+        if mode > 1:
+            os.environ["LD_BIND_NOW"] = "1"
+
 def main(steam_binary=STEAM_PATH):
     os.chdir(os.environ["HOME"]) # Ensure sane cwd
     print ("https://github.com/flathub/com.valvesoftware.Steam/wiki/Frequently-asked-questions")
@@ -237,4 +248,5 @@ def main(steam_binary=STEAM_PATH):
         migrate_cache()
     repair_broken_migration()
     timezone_workaround()
+    configure_shared_library_guard()
     os.execve(steam_binary, [steam_binary] + sys.argv[1:], os.environ)


### PR DESCRIPTION
Some boilerplate for taking into use the new audit library. It's at least for now an opt-in thing since it may have a performance impact. (glibc turns profiling on with audit libraries unnecessarily)
Mode 2 may mitigate the performance impact somewhat but loads all dynamic libraries on process startup.