### PR TITLE
Put libbfd in correct directory, fixing addr2line

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -159,10 +159,9 @@ modules:
       - |
         set -e
         mkdir -p /app/bin
-        mkdir -p /app/lib/x86_64-linux-gnu/
         mkdir -p /app/lib/i386-linux-gnu /app/lib/debug/lib/i386-linux-gnu
         cp /usr/bin/addr2line /app/bin/
-        cp /usr/lib/x86_64-linux-gnu/libbfd-2.31.1.so /app/lib/x86_64-linux-gnu
+        cp /usr/lib/x86_64-linux-gnu/libbfd-2.31.1.so /app/lib/
         install -Dm644 -t /app/etc ld.so.conf
         install -Dm644 -t /app/etc freedesktop.ld.so.blockedlist
         install -Dm744 -t /app/bin lsb_release


### PR DESCRIPTION
I've suddenly notices that `libbfd-2.31.1.so` is copied into `/app/lib/x86_64-linux-gnu`, which is not under ld library path. Thus, `addr2line` isn't working.