### PR TITLE
Add support for gamemode (1.4)

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -107,6 +107,17 @@ modules:
 
   - "modules/proton.yml"
 
+  - name: gamemode
+    buildsystem: meson
+    config-opts:
+      - -Dwith-systemd=false
+      - -Dwith-daemon=false
+      - -Dwith-examples=false
+    sources:
+      - type: git
+        url: https://github.com/FeralInteractive/gamemode
+        commit: 76a6fb709f61f90d794ec5c12cc2896eb89aa811
+
   - name: steam_wrapper
     buildsystem: simple
     sources:


### PR DESCRIPTION
(Re-)introduce support for GameMode; using the _not-yet-released_ version 1.4, which gained support for using the new [GameMode portal](https://github.com/flatpak/xdg-desktop-portal/pull/314). Using the portal should resolve the previous issues where the pid-namespace encapsulation was preventing for the host GameMode daemon to properly track the games.

I have verified it actually works: 
```
Jul 12 16:56:51 hanada.local /usr/bin/gamemoded[15762]: Adding game: 6485 [/home/gicmo/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/Rise of the Tomb Raider/bin/RiseOf of the Tomb Raider/bin/RiseOfTheTombRaider]
Jul 12 16:56:51 hanada.local /usr/bin/gamemoded[15762]: Entering Game Mode...
Jul 12 16:56:51 hanada.local /usr/bin/gamemoded[15762]: governor was initially set to [powersave]
Jul 12 16:56:51 hanada.local /usr/bin/gamemoded[15762]: Requesting update of governor policy to performance
Jul 12 16:56:51 hanada.local pkexec[6495]: pam_unix(polkit-1:session): session opened for user root by (uid=1000)
Jul 12 16:56:51 hanada.local /usr/bin/gamemoded[15762]: Setting ioprio value...
Jul 12 16:56:51 hanada.local /usr/bin/gamemoded[15762]: Skipping ioprio on client [6485,6485]: ioprio was (0) but we expected (4)
Jul 12 17:00:07 hanada.local /usr/bin/gamemoded[15762]: Removing expired game [6485]...
Jul 12 17:00:07 hanada.local /usr/bin/gamemoded[15762]: Removing game: 6485 [/home/gicmo/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/Rise of the Tomb Raider/bin/Rise of the Tomb Raider/bin/RiseOfTheTombRaider]
Jul 12 17:00:07 hanada.local /usr/bin/gamemoded[15762]: Leaving Game Mode...
Jul 12 17:00:07 hanada.local /usr/bin/gamemoded[15762]: Requesting update of governor policy to powersave
Jul 12 17:00:07 hanada.local pkexec[7047]: pam_unix(polkit-1:session): session opened for user root by (uid=1000)
Jul 12 17:00:07 hanada.local /usr/bin/gamemoded[15762]: Setting ioprio value...
Jul 12 17:00:07 hanada.local /usr/bin/gamemoded[15762]: Could not inspect tasks for client [6485]! Skipping ioprio optimisation.
Jul 12 17:00:07 hanada.local /usr/bin/gamemoded[15762]: Properly cleaned up all expired games.
```
This should finally close issue #77 