### PR TITLE
Update FAudio to 0.19.07 for Proton 4.11

### DIFF
--- a/modules/proton.yml
+++ b/modules/proton.yml
@@ -4,8 +4,8 @@ config-opts:
   - -DFFMPEG=ON
 sources:
   - type: archive
-    url: https://github.com/FNA-XNA/FAudio/archive/19.06.07.tar.gz
-    sha256: 3a062ac74e787d2c50a5d178e9021ca4b2d4dddbbea6d36b82c767eb7f957128
+    url: https://github.com/FNA-XNA/FAudio/archive/19.07.tar.gz
+    sha256: b05ca9cbdaf943deadae124dcc437e1106d525ab7f54b62c74dcb2eaead21178
 modules:
   - name: ffmpeg
     config-opts:

--- a/resources/freedesktop.ld.so.blockedlist
+++ b/resources/freedesktop.ld.so.blockedlist
@@ -103,3 +103,5 @@ Proton\ 3.16\ Beta/dist/bin/wine64 Proton\ 3.16\ Beta/dist/lib64/libFAudio.so
 Proton\ 3.16\ Beta/dist/bin/wine64-preloader Proton\ 3.16\ Beta/dist/lib64/libFAudio.so
 Proton\ 4.2/dist/bin/wine64 Proton\ 4.2/dist/lib64/libFAudio.so.0.19.06
 Proton\ 4.2/dist/bin/wine64-preloader Proton\ 4.2/dist/lib64/libFAudio.so.0.19.06
+Proton\ 4.11/dist/bin/wine64 Proton\ 4.11/dist/lib64/libFAudio.so.0.19.07
+Proton\ 4.11/dist/bin/wine64-preloader Proton\ 4.11/dist/lib64/libFAudio.so.0.19.07


### PR DESCRIPTION
The new Proton 4.11 shipped with FAudio 0.19.07.
I'm still not sure what we should put in the blocklist - the actual library (`libFAudio.so.0.19.07`), the major-versioned symlink which wine is linked with (`libFAudio.so.0`), or both?