### PR TITLE
Update google-perftools

### DIFF
--- a/modules-32bit.yml
+++ b/modules-32bit.yml
@@ -87,5 +87,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/gperftools/gperftools.git
-        commit: 0b87a55895a184bcc529b4ce13c46c0411182b85
-        tag: google-perftools-1.8.3
+        commit: 9608fa3bcf8020d35f59fbf70cd3cbe4b015b972
+        tag: gperftools-2.7


### PR DESCRIPTION
#387 added `libtcmalloc_minimal.so.0.2.2`, while we need to provide `libtcmalloc_minimal.so.4` in order to fix #18 and #105.