### PR TITLE
Disable systemd-resolved in systemd build

### DIFF
--- a/modules/controllers.yml
+++ b/modules/controllers.yml
@@ -45,6 +45,9 @@ modules:
       - -Dbashcompletiondir=no
       - -Dzshcompletiondir=no
       - -Dresolve=false
+      - -Dnss-resolve=false
+      - -Dnss-myhostname=false
+      - -Dnss-systemd=false
     sources:
       - type: archive
         url: https://github.com/systemd/systemd/archive/v242.tar.gz

--- a/modules/controllers.yml
+++ b/modules/controllers.yml
@@ -44,6 +44,7 @@ modules:
       - -Dmicrohttpd=false
       - -Dbashcompletiondir=no
       - -Dzshcompletiondir=no
+      - -Dresolve=false
     sources:
       - type: archive
         url: https://github.com/systemd/systemd/archive/v242.tar.gz


### PR DESCRIPTION
systemd-resolved shouldn't be needed. It's also unlikely to work at all.
