### PR TITLE
Add /app/lib32 to ld.so.conf

### DIFF
--- a/resources/ld.so.conf
+++ b/resources/ld.so.conf
@@ -1,4 +1,5 @@
 # We just make any GL32 extension have higher priority
 include /run/flatpak/ld.so.conf.d/app-*-org.freedesktop.Platform.GL32.*.conf
+/app/lib32
 /app/lib/i386-linux-gnu
 /lib64


### PR DESCRIPTION
This is needed for 32-bit modules to be actually usable.