### PR TITLE
Make LD_AUDIT use glibc arch resolving

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -176,6 +176,9 @@ modules:
         install -Dm644 -t /app/etc freedesktop-sdk.ld.so.blockedlist
         install -Dm744 -t /app/bin lsb_release
         mkdir /app/compatibilitytools.d
+        mkdir /app/links
+        ln -s /app/lib /app/links/x86_64-linux-gnu
+        ln -s /app/lib32 /app/links/i386-linux-gnu
     sources:
       - type: file
         path: resources/ld.so.conf

--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -239,9 +239,7 @@ def configure_shared_library_guard():
     if not mode:
         return
     else:
-        library = "libshared-library-guard.so"
-        os.environ["LD_AUDIT"] = os.pathsep.join((f"/app/lib/{library}",
-                                                  f"/app/lib32/{library}"))
+        os.environ["LD_AUDIT"] = f"/app/links/$LIB/libshared-library-guard.so"
 
 def setup_compat_tool_extensions(current_info):
     compat_tool_dest = Path('.local/share/Steam/compatibilitytools.d')


### PR DESCRIPTION
This should get rid of incorrect arch spam when shared-libary-guard
is enabled