### PR TITLE
Release beta to master

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,5 @@
 #!/bin/sh -e
-dependencies="--install-deps-from=flathub"
-for name in $*
-do
-    dependencies="--install-deps-from $name $dependencies"
-done
-flatpak-builder --user $dependencies --repo=steam --force-clean build-dir com.valvesoftware.Steam.yml
+flatpak-builder --user --repo=steam --force-clean build-dir com.valvesoftware.Steam.yml
 flatpak --user remote-add --no-gpg-verify --if-not-exists steam steam
 flatpak install steam com.valvesoftware.Steam
 flatpak update com.valvesoftware.Steam

--- a/resources/freedesktop-sdk.ld.so.blockedlist
+++ b/resources/freedesktop-sdk.ld.so.blockedlist
@@ -79,6 +79,7 @@ Sid\ Meier\'s\ Civilization\ VI/GameGuide/libexec/QtWebEngineProcess Sid\ Meier\
 Sid\ Meier\'s\ Civilization\ VI/GameGuide/libexec/QtWebEngineProcess Sid\ Meier\'s\ Civilization\ VI/GameGuide/lib/libxslt.so.1
 Sid\ Meier\'s\ Civilization\ VI/GameGuide/libexec/QtWebEngineProcess Sid\ Meier\'s\ Civilization\ VI/GameGuide/lib/libXtst.so.6
 Sid\ Meier\'s\ Civilization\ VI/GameGuide/libexec/QtWebEngineProcess Sid\ Meier\'s\ Civilization\ VI/GameGuide/lib/libXxf86vm.so.1
+ShadowOfMordor/bin/ShadowOfMordor steam-runtime/amd64/usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0.9.0
 Proton\ 3.7/dist/bin/wine64 Proton\ 3.7/dist/lib64/libFAudio.so
 Proton\ 3.7/dist/bin/wine64-preloader Proton\ 3.7/dist/lib64/libFAudio.so
 Proton\ 3.7\ Beta/dist/bin/wine64 Proton\ 3.7\ Beta/dist/lib64/libFAudio.so


### PR DESCRIPTION
Closes #417, prevents Steam runtime libSDL from being loaded for Shadow of Mordor. This is not a nice workaround.