### PR TITLE
Update FAudio to v19.09

### DIFF
--- a/sources/FAudio-archive.json
+++ b/sources/FAudio-archive.json
@@ -1,5 +1,5 @@
 {
   "type": "archive",
-  "url": "https://github.com/FNA-XNA/FAudio/archive/19.08.tar.gz",
-  "sha256": "78f66af91ec45fe93c0aed9ad40f5ebb226f8ee1e12ec61ab9da6349dc9188a8"
+  "url": "https://github.com/FNA-XNA/FAudio/archive/19.09.tar.gz",
+  "sha256": "754b5ccc239bc1be4046d254748cface915e653aec179424fd452255a7082677"
 }


### PR DESCRIPTION
The new Proton 4.11-4 shipped with FAudio 19.09.
