### PR TITLE
Generate Proton blocklist at build time

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -174,6 +174,7 @@ modules:
         cp /usr/lib/x86_64-linux-gnu/libbfd-*.so /app/lib/
         install -Dm644 -t /app/etc ld.so.conf
         install -Dm644 -t /app/etc freedesktop-sdk.ld.so.blockedlist
+        ./gen-proton-blocklist.sh >> /app/etc/freedesktop-sdk.ld.so.blockedlist
         install -Dm744 -t /app/bin lsb_release
         mkdir /app/compatibilitytools.d
         mkdir /app/links
@@ -184,5 +185,7 @@ modules:
         path: resources/ld.so.conf
       - type: file
         path: resources/freedesktop-sdk.ld.so.blockedlist
+      - type: file
+        path: resources/gen-proton-blocklist.sh
       - type: file
         path: resources/lsb_release

--- a/resources/freedesktop-sdk.ld.so.blockedlist
+++ b/resources/freedesktop-sdk.ld.so.blockedlist
@@ -80,15 +80,3 @@ Sid\ Meier\'s\ Civilization\ VI/GameGuide/libexec/QtWebEngineProcess Sid\ Meier\
 Sid\ Meier\'s\ Civilization\ VI/GameGuide/libexec/QtWebEngineProcess Sid\ Meier\'s\ Civilization\ VI/GameGuide/lib/libXtst.so.6
 Sid\ Meier\'s\ Civilization\ VI/GameGuide/libexec/QtWebEngineProcess Sid\ Meier\'s\ Civilization\ VI/GameGuide/lib/libXxf86vm.so.1
 ShadowOfMordor/bin/ShadowOfMordor steam-runtime/amd64/usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0.9.0
-Proton\ 3.7/dist/bin/wine64 Proton\ 3.7/dist/lib64/libFAudio.so
-Proton\ 3.7/dist/bin/wine64-preloader Proton\ 3.7/dist/lib64/libFAudio.so
-Proton\ 3.7\ Beta/dist/bin/wine64 Proton\ 3.7\ Beta/dist/lib64/libFAudio.so
-Proton\ 3.7\ Beta/dist/bin/wine64-preloader Proton\ 3.7\ Beta/dist/lib64/libFAudio.so
-Proton\ 3.16/dist/bin/wine64 Proton\ 3.16/dist/lib64/libFAudio.so
-Proton\ 3.16/dist/bin/wine64-preloader Proton\ 3.16/dist/lib64/libFAudio.so
-Proton\ 3.16\ Beta/dist/bin/wine64 Proton\ 3.16\ Beta/dist/lib64/libFAudio.so
-Proton\ 3.16\ Beta/dist/bin/wine64-preloader Proton\ 3.16\ Beta/dist/lib64/libFAudio.so
-Proton\ 4.2/dist/bin/wine64 Proton\ 4.2/dist/lib64/libFAudio.so.0.19.06
-Proton\ 4.2/dist/bin/wine64-preloader Proton\ 4.2/dist/lib64/libFAudio.so.0.19.06
-Proton\ 4.11/dist/bin/wine64 Proton\ 4.11/dist/lib64/libFAudio.so.0.19.08
-Proton\ 4.11/dist/bin/wine64-preloader Proton\ 4.11/dist/lib64/libFAudio.so.0.19.08

--- a/resources/gen-proton-blocklist.sh
+++ b/resources/gen-proton-blocklist.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+declare -A PROTON_BLOCK_LIBS
+
+PROTON_BLOCK_LIBS["Proton 3.7"]="libFAudio.so"
+PROTON_BLOCK_LIBS["Proton 3.7 Beta"]="libFAudio.so"
+PROTON_BLOCK_LIBS["Proton 3.16"]="libFAudio.so"
+PROTON_BLOCK_LIBS["Proton 3.16 Beta"]="libFAudio.so"
+PROTON_BLOCK_LIBS["Proton 4.2"]="libFAudio.so.0.19.06"
+PROTON_BLOCK_LIBS["Proton 4.11"]="libFAudio.so.19.08 libFAudio.so.19.09"
+
+for proton in "${!PROTON_BLOCK_LIBS[@]}"; do
+    dist_dir=$(printf '%q' "${proton}/dist")
+    for block_lib in ${PROTON_BLOCK_LIBS[$proton]}; do
+        for arch_suffix in "64" ""; do
+            for wine_bin in "wine${arch_suffix}" "wine${arch_suffix}-preloader"; do
+                echo "${dist_dir}/bin/${wine_bin} ${dist_dir}/lib${arch_suffix}/${block_lib}"
+            done
+        done
+    done
+done


### PR DESCRIPTION
This adds a simple script that generates ld.so.blockedlist part for Proton. This way, we only need to define which Proton versions comes with which FAudio versions, the script will append necessary lines to the blocklist at build time.
Supersedes and closes #438.