### PR TITLE
Fix FAudio blocklist name

### DIFF
--- a/resources/blocklist/proton.yml
+++ b/resources/blocklist/proton.yml
@@ -67,7 +67,7 @@ entries:
           - path: bin/wine64-preloader
             libdir: lib64
         libraries:
-          - path: libFAudio.so.19.06
+          - path: libFAudio.so.0.19.06
 
   - basedir: "*(/*)/Proton 4.11/dist"
     blocklists:
@@ -81,5 +81,5 @@ entries:
           - path: bin/wine64-preloader
             libdir: lib64
         libraries:
-          - path: libFAudio.so.19.08
-          - path: libFAudio.so.19.09
+          - path: libFAudio.so.0.19.08
+          - path: libFAudio.so.0.19.09


### PR DESCRIPTION
Some 0's got dropped in recent commits, added them back based on the old
blocklist files. libFAudio.so.0.19.09 was tested with SkyrimSE in Proton 4.11-5.
