### PR TITLE
Simplify usage of shared-library-guard-config-converter

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -166,10 +166,7 @@ modules:
         cp /usr/bin/addr2line /app/bin/
         cp /usr/lib/x86_64-linux-gnu/libbfd-*.so /app/lib/
         install -Dm644 -t /app/etc ld.so.conf
-        for name in blocklist/*
-        do
-        shared-library-guard-config-converter $name >> /app/etc/freedesktop-sdk.ld.so.blockedlist
-        done
+        shared-library-guard-config-converter blocklist/* 
         install -Dm744 -t /app/bin lsb_release
         mkdir /app/compatibilitytools.d
         mkdir /app/links

--- a/sources/shared-library-guard-git.json
+++ b/sources/shared-library-guard-git.json
@@ -1,6 +1,6 @@
 {
     "type": "git",
     "url": "https://gitlab.com/freedesktop-sdk/shared-library-guard",
-    "commit": "bf35127b8b3881ffa30a06069dddd14da22c7c50",
-    "tag": "v19.09.2"
+    "commit": "57dc1fde74c17f502a53e6ecf7cb34d038cbc753",
+    "tag": "v19.09.3"
 }


### PR DESCRIPTION
The converter now supports multiple input files directly