### PR TITLE
Blocklist for F1 2015

### DIFF
--- a/resources/blocklist/f1_2015.yml
+++ b/resources/blocklist/f1_2015.yml
@@ -1,0 +1,8 @@
+entries:
+  - basedir: "*(/*|/.*)/F1 2015/bin/"
+    blocklists:
+      - binaries:
+          - path: "F12015"
+        libraries:
+          - path: "*(/*|/.*)/steam-runtime+(/*)/libSDL2-2.0.so.0.9.0"
+            no-prefix: true


### PR DESCRIPTION
I get 
```
/home/rebecca/.local/share/Steam/steamapps/common/F1 2015/bin/F12015: symbol lookup error: /usr/lib/x86_64-linux-gnu/libSDL2_image-2.0.so.0: undefined symbol: SDL_RWread
```
when trying to run F1 2015. Is this the correct way to add a blocklist entry?