### PR TITLE
Add support for flatpak-external-data-checker

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -141,6 +141,11 @@ modules:
       - type: archive
         url: http://repo.steampowered.com/steam/archive/precise/steam_latest.tar.gz
         sha256: d66413cce9c9ad441f95c4377103b0c71bda4ac4570ecfc7dd2464fe4ef1bd30
+        x-checker-data:
+          type: html
+          url: "http://repo.steampowered.com/steam/archive/precise/"
+          version-pattern: steam_([\d.-]+).tar.gz
+          url-pattern: (steam_[\d.-]+.tar.gz)
       - type: file
         path: com.valvesoftware.Steam.metainfo.xml
 


### PR DESCRIPTION
The data-checker should automatically check for new upstream releases and open a PR with changes like this:
```
CHANGE SOON: steam_latest.tar.gz
 Has a new version:
  URL:     http://repo.steampowered.com/steam/archive/precise/steam_1.0.0.61.tar.gz
  SHA256:  d66413cce9c9ad441f95c4377103b0c71bda4ac4570ecfc7dd2464fe4ef1bd30
  Size:    2875970
  Version: 1.0.0.61
```