### PR TITLE
Add extension point for Vulkan layers

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -95,6 +95,13 @@ add-extensions:
     no-autodownload: true
     autodelete: true
 
+  com.valvesoftware.Steam.VulkanLayer:
+    directory: layers
+    subdirectories: true
+    merge-dirs: share/vulkan/explicit_layer.d;share/vulkan/implicit_layer.d;
+    no-autodownload: true
+    autodelete: true
+
 cleanup:
   - /lib/*.a
   - /lib/*.la
@@ -187,6 +194,9 @@ modules:
         install -Dm744 -t /app/bin lsb_release
         mkdir -p /app/share/steam/compatibilitytools.d
         mkdir -p /app/utils
+        mkdir -p /app/layers /app/share/vulkan
+        ln -srv /app/{layers/,}share/vulkan/explicit_layer.d
+        ln -srv /app/{layers/,}share/vulkan/implicit_layer.d
         mkdir /app/links
         ln -s /app/lib /app/links/x86_64-linux-gnu
         ln -s /app/lib32 /app/links/i386-linux-gnu


### PR DESCRIPTION
There are several Vulkan layers intended for gaming, most notably MangoHud and vkBasalt.
They can be packaged as flatpaks and used with Steam - to do so, we first need an extension point to plug them onto.

Tested it with MangoHud built from [this manifest](https://github.com/gasinvein/flatpak-apps-staging/blob/com.valvesoftware.Steam.VulkanLayer.MangoHud/master/com.valvesoftware.Steam.VulkanLayer.MangoHud.yml), it worked out of the box.