### PR TITLE
Bump SPIRV-Headers from 1.5.1 to 1.5.3

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -98,8 +98,8 @@ modules:
     buildsystem: cmake-ninja
     sources:
       - type: archive
-        url: "https://github.com/KhronosGroup/SPIRV-Headers/archive/1.5.1.corrected.tar.gz"
-        sha256: 2b6a0ce1c02b9fe7b9ef727369168fe579e5256f1ea013993acdb8d8f06b7e89
+        url: "https://github.com/KhronosGroup/SPIRV-Headers/archive/1.5.3.tar.gz"
+        sha256: eece8a9e147d37997d425d5d2eeb2e757ad25adc30d6651467094f3b18609b5a
 
   - name: vkd3d
     sources:


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
