### PR TITLE
Bump FAudio from 20.06 to 20.07

### DIFF
--- a/resources/blocklist/proton.yml
+++ b/resources/blocklist/proton.yml
@@ -66,6 +66,7 @@ entries:
           - path: libFAudio.so.0.20.04
           - path: libFAudio.so.0.20.05
           - path: libFAudio.so.0.20.06
+          - path: libFAudio.so.0.20.07
 
 
   - basedir: "*(/*|/.*)/Proton 5.0/dist"

--- a/sources/FAudio-archive.json
+++ b/sources/FAudio-archive.json
@@ -1,5 +1,5 @@
 {
   "type": "archive",
-  "url": "https://github.com/FNA-XNA/FAudio/archive/20.06.tar.gz",
-  "sha256": "d6e89e1d5d2a95e2c2759318c6dba6ecd922c452668996e6e7e40294c3875725"
+  "url": "https://github.com/FNA-XNA/FAudio/archive/20.07.tar.gz",
+  "sha256": "65f63726a06083871abd60e69d94f1df2d9f6f4dea8d4d627b0f5d87847deacc"
 }


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
