### PR TITLE
Fix links directories

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -200,9 +200,9 @@ modules:
         mkdir -p /app/utils /app/share/vulkan
         ln -srv /app/{utils/,}share/vulkan/explicit_layer.d
         ln -srv /app/{utils/,}share/vulkan/implicit_layer.d
-        mkdir /app/links
-        ln -s /app/lib /app/links/x86_64-linux-gnu
-        ln -s /app/lib32 /app/links/i386-linux-gnu
+        mkdir -p /app/links/lib
+        ln -s /app/lib /app/links/lib/x86_64-linux-gnu
+        ln -s /app/lib32 /app/links/lib/i386-linux-gnu
     sources:
       - type: dir
         path: resources


### PR DESCRIPTION
In 20.08 $LIB refers to `lib/x86-64-linux-gnu` or
`lib/i386-linux-gnu`. This is different than in 19.08.
