### PR TITLE
Bump FAudio from 20.08 to 20.09

### DIFF
--- a/resources/blocklist/proton.yml
+++ b/resources/blocklist/proton.yml
@@ -68,7 +68,7 @@ entries:
           - path: libFAudio.so.0.20.06
           - path: libFAudio.so.0.20.07
           - path: libFAudio.so.0.20.08
-
+          - path: libFAudio.so.0.20.09
 
   - basedir: "*(/*|/.*)/Proton 5.0/dist"
     blocklists:

--- a/sources/FAudio-archive.json
+++ b/sources/FAudio-archive.json
@@ -1,5 +1,5 @@
 {
   "type": "archive",
-  "url": "https://github.com/FNA-XNA/FAudio/archive/20.08.tar.gz",
-  "sha256": "5c3409fa0e532591f0ab4de1ae57d07cc345efa5cbe83ec25e9f5ba180f920f4"
+  "url": "https://github.com/FNA-XNA/FAudio/archive/20.09.tar.gz",
+  "sha256": "375d12ba57f507b95e030926fd08308029b38af883d0524583a2d5d8fe65168b"
 }


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
