### PR TITLE
Revert "Remove xrandr"

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -87,6 +87,12 @@ modules:
         url: https://download.gnome.org/sources/gnome-common/3.18/gnome-common-3.18.0.tar.xz
         sha256: 22569e370ae755e04527b76328befc4c73b62bfd4a572499fde116b8318af8cf
 
+  - name: xrandr
+    sources:
+      - type: archive
+        url: https://xorg.freedesktop.org/archive/individual/app/xrandr-1.5.1.tar.xz
+        sha256: 7bc76daf9d72f8aff885efad04ce06b90488a1a169d118dea8a2b661832e8762
+
   - name: libbsd
     sources:
       - type: archive


### PR DESCRIPTION
This reverts commit b6859176a46e472bcd7813ca9b39626c1b3eec6a.

Closes #619. Confused it with libxrandr.

<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
