### PR TITLE
Backup config and data on migration

### DIFF
--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -129,8 +129,11 @@ def migrate_config():
     """
     source = os.path.expandvars("$XDG_CONFIG_HOME")
     target = CONFIG
+    backup = f'{CONFIG}.bak'
     relocated = os.path.expandvars("$XDG_CONFIG_HOME.old")
     if not os.path.islink(source):
+        if os.path.isdir(target):
+            copytree(target, backup)
         copytree(source, target)
         os.rename(source, relocated)
         os.symlink(target, source)
@@ -146,9 +149,12 @@ def migrate_data():
     """
     source = os.path.expandvars("$XDG_DATA_HOME")
     target = DATA
+    backup = f'{DATA}.bak'
     steam_home = os.path.join(source, "Steam")
     xdg_data_home = os.path.join(STEAM_ROOT, target)
     if not os.path.islink(source):
+        if os.path.isdir(target):
+            copytree(target, backup)
         copytree(source, target, ignore=[steam_home])
         if os.path.isdir(steam_home):
             os.rename(steam_home,


### PR DESCRIPTION
Since we are now migrating data without asking for user consent, we should make sure that files to be overwritten aren't lost permanently. So, backup `~/.config` and `~/.local/share` if present, just in case.

Follow-up for #622 