### PR TITLE
com.valvesoftware.Steam.yml: add more locale settings to prenvent some crashes

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -38,8 +38,13 @@ finish-args:
   - --allow=bluetooth
   - --persist=.
   - --env=TZ=
-  - --env=LC_NUMERIC=C
+  - --env=LC_ADDRESS=C
   - --env=LC_COLLATE=C
+  - --env=LC_MONETARY=C
+  - --env=LC_MEASUREMENT=C
+  - --env=LC_NAME=C
+  - --env=LC_NUMERIC=C
+  - --env=LC_TELEPHONE=C
   - --env=ALSA_CONFIG_PATH=
   - --env=MESA_GLSL_CACHE_DIR=
   - --env=STEAM_RUNTIME_PREFER_HOST_LIBRARIES=


### PR DESCRIPTION
Solves crashes on:
* Shadow of the Tomb Raider
* Interplanetary Enhanced Edition

This set is actually minimal (!) and other settings will cause SotTR to crash
when faced with "bizarre" locales, such as French.

<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
