### PR TITLE
Allow test branch for extensions

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -88,12 +88,16 @@ add-extensions:
   com.valvesoftware.Steam.CompatibilityTool:
     subdirectories: true
     directory: share/steam/compatibilitytools.d
+    version: beta
+    versions: beta;test
     no-autodownload: true
     autodelete: true
 
   com.valvesoftware.Steam.Utility:
     subdirectories: true
     directory: utils
+    version: beta
+    versions: beta;test
     add-ld-path: lib
     merge-dirs: share/vulkan/explicit_layer.d;share/vulkan/implicit_layer.d;
     no-autodownload: true


### PR DESCRIPTION
Add `test` branch to `versions`, so flatpak will pick up test builds of extensions if they're installed.
Currently, there is no easy way to use Flathub's test builds of Steam flatpak extensions, since `test` branch doesn't match `stable` or `beta` and flatpak doesn't enable them.

I guess `beta` here will need to be changed to `stable` when merging to git master.