### PR TITLE
Fix str.lstrip() misuse in wrapper

### DIFF
--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -44,6 +44,11 @@ def read_flatpak_info(path):
                                         fallback="").split(";")
     }
 
+def strip_prefix(string, prefix):
+    if not string.startswith(prefix):
+        raise ValueError(f"{string} doesn't match prefix {prefix}")
+    return string[len(prefix):]
+
 def read_file(path):
     try:
         with open(path, "r") as f:
@@ -203,7 +208,7 @@ def enable_extensions(flatpak_info):
     for ext_id in flatpak_info["app-extensions"]:
         if not ext_id.startswith(f"{UTIL_EXT_BASE_ID}."):
             continue
-        ext_name = ext_id.lstrip(f"{UTIL_EXT_BASE_ID}.")
+        ext_name = strip_prefix(ext_id, f"{UTIL_EXT_BASE_ID}.")
         ext_dir = os.path.join(UTIL_EXT_BASE_DIR, ext_name)
         for env, subdirs in UTIL_EXT_PATHS.items():
             paths = [i for i in os.environ.get(env, "").split(os.pathsep) if i]


### PR DESCRIPTION
Remove extension point prefix from extension ID properly.
In #633, I've misused Python's `str.lstrip()` method to remove leading character sequence, which is not suitable for that.
This could result in wrong (cropped) extension directory names, which would result in extensions not actually enabled. Luckily this didn't fire yet.