### PR TITLE
Use stable branch for extensions in Steam stable branch

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -93,16 +93,16 @@ add-extensions:
   com.valvesoftware.Steam.CompatibilityTool:
     subdirectories: true
     directory: share/steam/compatibilitytools.d
-    version: beta
-    versions: beta;test
+    version: stable
+    versions: stable;test
     no-autodownload: true
     autodelete: true
 
   com.valvesoftware.Steam.Utility:
     subdirectories: true
     directory: utils
-    version: beta
-    versions: beta;test
+    version: stable
+    versions: stable;test
     add-ld-path: lib
     merge-dirs: share/vulkan/explicit_layer.d;share/vulkan/implicit_layer.d;
     no-autodownload: true


### PR DESCRIPTION
We don't want the `stable` app to use `beta` extensions.
Note that this PR is targeting git `master` branch and should be merged only there.