### PR TITLE
Revert "Enable utils extensions via wrapper"

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -53,6 +53,8 @@ finish-args:
   - --env=DBUS_FATAL_WARNINGS=0
   - --env=SSL_CERT_DIR=/etc/ssl/certs
   - --env=STEAM_EXTRA_COMPAT_TOOLS_PATHS=/app/share/steam/compatibilitytools.d
+  - --env=PATH=/app/bin:/app/utils/bin:/usr/bin
+  - --env=PYTHONPATH=/app/utils/lib/python3.8/site-packages
   - --env=PROTON_DEBUG_DIR=/var/tmp
   - --env=XDG_CONFIG_DIRS=/etc/xdg:/usr/lib/x86_64-linux-gnu/GL:/usr/lib/i386-linux-gnu/GL
   - --require-version=1.0.0
@@ -104,7 +106,7 @@ add-extensions:
     version: beta
     versions: beta;test
     add-ld-path: lib
-    merge-dirs: share/vulkan/explicit_layer.d;share/vulkan/implicit_layer.d;
+    merge-dirs: bin;lib/python3.8/site-packages;share/vulkan/explicit_layer.d;share/vulkan/implicit_layer.d;
     no-autodownload: true
     autodelete: true
 

--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -18,13 +18,6 @@ CONFIG = ".config"
 DATA = ".local/share"
 CACHE = ".cache"
 FLATPAK_INFO = "/.flatpak-info"
-PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
-UTIL_EXT_BASE_ID = "com.valvesoftware.Steam.Utility"
-UTIL_EXT_BASE_DIR = "/app/utils"
-UTIL_EXT_PATHS = {
-    "PATH": ["bin"],
-    "PYTHONPATH": [f"lib/python{PYTHON_VERSION}/site-packages"],
-}
 
 
 def read_flatpak_info(path):
@@ -198,23 +191,6 @@ def configure_shared_library_guard():
     else:
         os.environ["LD_AUDIT"] = f"/app/links/$LIB/libshared-library-guard.so"
 
-
-def enable_extensions(flatpak_info):
-    for ext_id in flatpak_info["app-extensions"]:
-        if not ext_id.startswith(f"{UTIL_EXT_BASE_ID}."):
-            continue
-        ext_name = ext_id.lstrip(f"{UTIL_EXT_BASE_ID}.")
-        ext_dir = os.path.join(UTIL_EXT_BASE_DIR, ext_name)
-        for env, subdirs in UTIL_EXT_PATHS.items():
-            paths = [i for i in os.environ.get(env, "").split(os.pathsep) if i]
-            for subdir in subdirs:
-                ext_path = os.path.join(ext_dir, subdir)
-                if os.path.isdir(ext_path):
-                    paths.append(ext_path)
-            if paths:
-                os.environ[env] = os.pathsep.join(paths)
-
-
 def main(steam_binary=STEAM_PATH):
     os.chdir(os.environ["HOME"]) # Ensure sane cwd
     print ("https://github.com/flathub/com.valvesoftware.Steam/wiki/Frequently-asked-questions")
@@ -226,5 +202,4 @@ def main(steam_binary=STEAM_PATH):
     timezone_workaround()
     configure_shared_library_guard()
     enable_discord_rpc()
-    enable_extensions(current_info)
     os.execv(steam_binary, [steam_binary] + sys.argv[1:])


### PR DESCRIPTION
I think it's better to leave things as they were before #633, until we figure out a better way to deal with commands in extensions.
flatpak/flatpak#3006 could help with this a lot if someone implements it.

Requires flathub/com.valvesoftware.Steam.Utility.protontricks#15 to fix #651 