### PR TITLE
Install prime-run helper

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -219,3 +219,11 @@ modules:
     sources:
       - type: dir
         path: resources
+
+  - name: prime-run
+    buildsystem: simple
+    sources:
+      - type: file
+        path: prime-run
+    build-commands:
+      - install -Dm755 -t /app/bin prime-run

--- a/prime-run
+++ b/prime-run
@@ -1,0 +1,2 @@
+#!/bin/bash
+__NV_PRIME_RENDER_OFFLOAD=1 __VK_LAYER_NV_optimus=NVIDIA_only __GLX_VENDOR_LIBRARY_NAME=nvidia "$@"


### PR DESCRIPTION
This script runs a command with the dedicated GPU on hybrid NVIDIA systems. It is GPL-licensed and comes from https://github.com/archlinux/svntogit-packages/tree/packages/nvidia-prime/trunk

I know #559 already helps but even with that, my dedicated GPU will still not be used in games, it only works with the helper scripts which set a couple of variables. I could copy and paste these to all games but `prime-run %command%` is much cleaner.