### PR TITLE
Build libusb both 32/64bit and keep devel files

### DIFF
--- a/modules-32bit.yml
+++ b/modules-32bit.yml
@@ -27,6 +27,8 @@ modules:
     build-options:
       arch:
         x86_64: *compat_i386_opts
+      ldflags: -L/app/lib32 -Wl,-z,relro,-z,now -Wl,--as-needed
+      ldflags-override: true
     sources:
       - sources/libusb-archive.json
 

--- a/modules-32bit.yml
+++ b/modules-32bit.yml
@@ -23,6 +23,13 @@ modules:
     sources:
       - sources/eudev-archive.json
 
+  - name: libusb-32bit
+    build-options:
+      arch:
+        x86_64: *compat_i386_opts
+    sources:
+      - sources/libusb-archive.json
+
 # -- discord --
 
   - name: discord-rpc-32bit

--- a/modules.yml
+++ b/modules.yml
@@ -24,7 +24,9 @@ modules:
     sources:
       - sources/eudev-archive.json
 
-  - shared-modules/libusb/libusb.json
+  - name: libusb
+    sources:
+      - sources/libusb-archive.json
 
   - name: usbutils
     config-opts:

--- a/sources/libusb-archive.json
+++ b/sources/libusb-archive.json
@@ -1,0 +1,5 @@
+{
+    "type":"archive",
+    "url":"https://github.com/libusb/libusb/archive/v1.0.23.tar.gz",
+    "sha256": "02620708c4eea7e736240a623b0b156650c39bfa93a14bcfa5f3e05270313eba"
+}


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
It is used by Wine, so, we need both 32 and 64-bit libusb, and also keep development files to build Proton.

libusb isn't updated frequently (latest version was released a year ago) , so I believe it won't add much maintenance burden.