### PR TITLE
Don't autodownload ffmpeg-full

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -96,12 +96,14 @@ add-extensions:
     directory: lib/ffmpeg
     add-ld-path: "."
     version: "20.08"
+    no-autodownload: true
     autodelete: false
 
   org.freedesktop.Platform.ffmpeg_full.i386:
     directory: lib32/ffmpeg
     add-ld-path: "."
     version: "20.08"
+    no-autodownload: true
     autodelete: false
 
   com.valvesoftware.Steam.CompatibilityTool:


### PR DESCRIPTION
Follow-up for #659 
I'm not sure if this is right, though. While `.ffmpeg-full` is likely to be already there pulled in by something else, `.ffmpeg_full.i386` isn't widely used or known. If we aren't going to autodownload ffmpeg-full, I guess we should at least do some run-time check if it's not installed and notify the user about it.