### PR TITLE
Put our FAQ into help, not faq

### DIFF
--- a/com.valvesoftware.Steam.metainfo.xml
+++ b/com.valvesoftware.Steam.metainfo.xml
@@ -20,9 +20,8 @@
     <category>PackageManager</category>
   </categories>
   <url type="homepage">https://store.steampowered.com/</url>
-  <url type="help">https://help.steampowered.com/</url>
+  <url type="help">https://github.com/flathub/com.valvesoftware.Steam/wiki/Frequently-asked-questions</url>
   <url type="bugtracker">https://github.com/flathub/com.valvesoftware.Steam/issues</url>
-  <url type="faq">https://github.com/flathub/com.valvesoftware.Steam/wiki/Frequently-asked-questions</url>
   <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Valve Corporation</developer_name>
   <screenshots>


### PR DESCRIPTION
It is more common for stores to expose help (eg Flatub and KDE
Discovery do this) but neither show FAQ link so it's mostly useless.

We can always direct users to Valve help through our FAQ
but it's better that they have first read flatpak-specific
advice

<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
