### PR TITLE
Add more filesystem checks to wrapper

### DIFF
--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -91,8 +91,10 @@ def copytree(source, target, ignore=None):
             os.utime(full_target)
 
 def check_bad_filesystem_entries(entries):
-    bad_names = ["home", "host", os.path.expandvars("/var/home/$USER"),
-         "/home/$USER"]
+    bad_names = ["home",
+                 "host",
+                 os.path.expandvars("/var/home/$USER"),
+                 os.path.expandvars("/home/$USER")]
     found = False
     for entry in entries:
         items = entry.split(";")

--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -95,11 +95,12 @@ def check_bad_filesystem_entries(entries):
                  "host",
                  os.path.expandvars("/var/home/$USER"),
                  os.path.expandvars("/home/$USER")]
+    bad_topdirs = ["xdg-config", "xdg-data", "xdg-cache"]
     found = False
     for entry in entries:
-        items = entry.split(";")
-        if items[0] in bad_names:
-            print (f"Bad item \"{items[0]}\" found in filesystem overrides")
+        assert ";" not in entry
+        if (entry in bad_names) or (os.path.split(entry)[0] in bad_topdirs):
+            print (f"Bad item \"{entry}\" found in filesystem overrides")
             found = True
     if found:
         faq = ("https://github.com/flathub/com.valvesoftware.Steam/wiki"


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
This should prevent same-file error on copying xdg-dirs during migration.
Steam will refuse to launch for users who added overrides like https://github.com/flathub/com.valvesoftware.Steam/issues/667#issuecomment-743480550. This is intentional.
Closes #667