### PR TITLE
Fix FAQ link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ This is a thin Flatpak wrapper for Steam using Freedesktop Runtime
 Please report [tested games](https://github.com/flathub/com.valvesoftware.Steam/wiki/Tested-Games) so we have better impression what
 works and what does not.
 
-If you're having issues, first see
-[frequently asked questions](https://github.com/flathub/com.valvesoftware.Steam/wiki/Frequently-asked-questions)
+If you're having issues, first see FAQ on [the wiki](https://github.com/flathub/com.valvesoftware.Steam/wiki)
 to see if you're hitting some corner-case that needs manual intervention. If your case isn't listed, file an issue in addition to adding an entry in tested games.
 
 Minimum version required 1.0.0


### PR DESCRIPTION
The FAQ link in the README is broken.
