### PR TITLE
Allow UDisks2 system talk name

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -24,6 +24,8 @@ finish-args:
   # connecting to wifi and so on.
   # In normal mode, it probably just gets info about current connection status.
   - --system-talk-name=org.freedesktop.NetworkManager
+  # Wine uses UDisks2 to enumerate disk drives
+  - --system-talk-name=org.freedesktop.UDisks2
   - --talk-name=org.kde.StatusNotifierWatcher
   - --system-talk-name=org.freedesktop.UPower
   - --talk-name=org.freedesktop.ScreenSaver


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
Wine uses UDisks to enumerate drives (backing `mountmgr.sys` implementation). This is mostly used in various installers and unlikely to be needed for games at run time, but since it can break things with very obscure errors (wine itself doesn't complain when it can't talk to udisks), I believe it's better to have UDisks2 available to Wine.