### PR TITLE
Set PULSE_LATENCY_MSEC by default to 60

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -53,6 +53,7 @@ finish-args:
   - --env=STEAM_RUNTIME=
   - --env=SDL_VIDEODRIVER=
   - --env=DBUS_FATAL_WARNINGS=0
+  - --env=PULSE_LATENCY_MSEC=60
   - --env=SSL_CERT_DIR=/etc/ssl/certs
   - --env=STEAM_EXTRA_COMPAT_TOOLS_PATHS=/app/share/steam/compatibilitytools.d
   - --env=PATH=/app/bin:/app/utils/bin:/usr/bin


### PR DESCRIPTION
Workaround for https://github.com/flathub/com.valvesoftware.Steam/issues/514

<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
