### PR TITLE
Allow selectively passing through xdg-config

### DIFF
--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -97,7 +97,7 @@ def check_bad_filesystem_entries(entries):
                  "host",
                  os.path.expandvars("/var/home/$USER"),
                  os.path.expandvars("/home/$USER")]
-    bad_topdirs = ["xdg-data", "xdg-cache"]
+    bad_topdirs = ["xdg-data", "xdg-cache", "home", "host"]
     found = False
     for entry in entries:
         assert ";" not in entry


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
User should be able to expose select parts of xdg-config-home to app. When exposed, we must not overwrite those. So calculate which items are exposed and skip processing them. When user next time starts app, filesystems get mounted properly on top of directory structure anyway. 