### PR TITLE
Migrate absolute paths under flatpak state dir

### DIFF
--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -96,12 +96,11 @@ def check_bad_filesystem_entries(entries):
                  "host",
                  os.path.expandvars("/var/home/$USER"),
                  os.path.expandvars("/home/$USER")]
-    bad_topdirs = ["xdg-config", "xdg-data", "xdg-cache"]
     found = False
     for entry in entries:
-        assert ";" not in entry
-        if (entry in bad_names) or (os.path.split(entry)[0] in bad_topdirs):
-            print (f"Bad item \"{entry}\" found in filesystem overrides")
+        items = entry.split(";")
+        if items[0] in bad_names:
+            print (f"Bad item \"{items[0]}\" found in filesystem overrides")
             found = True
     if found:
         faq = ("https://github.com/flathub/com.valvesoftware.Steam/wiki"


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
The idea is not to mess with files outside the flatpak state directory, e.g. migrate `~/.var/app/com.valvesoftware.Steam/config` to `~/.var/app/com.valvesoftware.Steam/.config` instead of `~/.config`. This way we won't cross mount point boundaries under destination directory.
Makes #672 and #691 obsolete.

This is ready for review, but **requires excessive testing**.