### PR TITLE
Unify migration logic

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MESSAGES CONTROL]
+disable=logging-fstring-interpolation

--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -7,6 +7,8 @@ import errno
 import fnmatch
 import configparser
 from distutils.version import LooseVersion
+import typing as t
+import logging
 
 
 STEAM_PATH = "/app/bin/steam"
@@ -52,7 +54,7 @@ def timezone_workaround():
     zone_name = read_file("/etc/timezone").rstrip()
     if zone_name and os.path.exists(f"/usr/share/zoneinfo/{zone_name}"):
         os.environ["TZ"] = zone_name
-        print (f"Overriding TZ to {zone_name}")
+        logging.info(f"Overriding TZ to {zone_name}")
 
 def ignored(name, patterns):
     for pattern in patterns:
@@ -86,7 +88,6 @@ def copytree(source, target, ignore=None):
         for f_name in f_names:
             full_source = os.path.join(root, f_name)
             full_target = os.path.join(target_root, f_name)
-            print (f"Relocating {full_source} to {full_target}")
             shutil.copy2(full_source, full_target)
             os.utime(full_target)
 
@@ -107,7 +108,7 @@ def check_bad_filesystem_entries(entries):
     for entry in entries:
         items = entry.split(";")
         if items[0] in bad_names:
-            print (f"Bad item \"{items[0]}\" found in filesystem overrides")
+            logging.warning(f"Bad item \"{items[0]}\" found in filesystem overrides")
             found = True
     if found:
         faq = ("https://github.com/flathub/com.valvesoftware.Steam/wiki"
@@ -131,6 +132,79 @@ def check_allowed_to_run(current_info):
         shutil.rmtree(steam_home)
 
 
+class Migrator:
+    def __init__(self, source: str, target: str,
+                 ignore: t.Optional[t.List[str]]=None,
+                 rename: t.Optional[t.List[str]]=None,
+                 two_steps=False, need_backup=True):
+        self.source = source
+        assert os.path.isabs(self.source)
+        self.target = target
+        assert os.path.isabs(self.target)
+        self.ignore = ignore or []
+        self.rename = rename or []
+        self.no_copy = list(set(self.ignore) | set(self.rename))
+        assert not any(os.path.isabs(i) for i in self.no_copy)
+        self.two_steps = two_steps
+        self.need_backup = need_backup
+        self.target_backup = f'{self.target}.bak'
+        self.relocated_source = f'{self.source}.old'
+        self.log = logging.getLogger("migration")
+
+    @property
+    def need_migration(self):
+        return not os.path.islink(self.source)
+
+    def do_migrate(self):
+        assert self.need_migration
+        # Back-up target if requested
+        if self.need_backup and os.path.isdir(self.target):
+            self.log.info(f"Copying {self.target} to {self.target_backup}, ignoring {self.no_copy}")
+            copytree(self.target, self.target_backup,
+                     ignore=[os.path.join(self.target, i) for i in self.no_copy])
+        # Copy source to target, rename nocopy subdirs
+        self.log.info(f"Copying {self.source} to {self.target}, ignoring {self.no_copy}")
+        copytree(self.source, self.target,
+                 ignore=[os.path.join(self.source, i) for i in self.no_copy])
+        for rename_path in self.rename:
+            if rename_path in self.ignore:
+                continue
+            _source = os.path.join(self.source, rename_path)
+            _target = os.path.join(self.target, rename_path)
+            if os.path.isdir(_source):
+                self.log.info(f"Renaming {_source} to {_target}")
+                os.rename(_source, _target)
+        # Remove or move aside source
+        if self.two_steps:
+            self.log.info(f"Renaming {self.source} to {self.relocated_source}")
+            os.makedirs(os.path.dirname(self.relocated_source), exist_ok=True)
+            os.rename(self.source, self.relocated_source)
+        else:
+            self.log.info(f"Deleting {self.source}")
+            shutil.rmtree(self.source)
+        # Replace source with symlink to target
+        target_rel = os.path.relpath(self.target, os.path.dirname(self.source))
+        self.log.info(f"Symlinking {self.source} to {target_rel}")
+        os.symlink(target_rel, self.source)
+
+    @property
+    def need_cleanup(self):
+        #TODO check if are not running cleanup right after migration
+        return self.two_steps and os.path.isdir(self.relocated_source)
+
+    def do_cleanup(self):
+        assert self.need_cleanup
+        self.log.info(f"Deleting {self.relocated_source}")
+        shutil.rmtree(self.relocated_source)
+        return [self.relocated_source]
+
+    def apply(self):
+        if self.need_migration:
+            self.do_migrate()
+        elif self.need_cleanup:
+            self.do_cleanup()
+
+
 def migrate_config():
     """
     There's bind-mounted contents inside config dir so we need to
@@ -138,19 +212,10 @@ def migrate_config():
     2) Next start of app, remove temp
     In theory this should not break everything
     """
-    source = os.path.expandvars("$XDG_CONFIG_HOME")
-    target = os.path.join(FLATPAK_STATE_DIR, DEFAULT_CONFIG_DIR)
-    backup = f'{target}.bak'
-    relocated = os.path.expandvars("$XDG_CONFIG_HOME.old")
-    if not os.path.islink(source):
-        if os.path.isdir(target):
-            copytree(target, backup)
-        copytree(source, target)
-        os.rename(source, relocated)
-        symlink_rel(target, source)
-    else:
-        if os.path.isdir(relocated):
-            shutil.rmtree(relocated)
+    migrator = Migrator(os.path.expandvars("$XDG_CONFIG_HOME"),
+                        os.path.join(FLATPAK_STATE_DIR, DEFAULT_CONFIG_DIR),
+                        two_steps=True)
+    migrator.apply()
     os.environ["XDG_CONFIG_HOME"] = os.path.expandvars(f"$HOME/{DEFAULT_CONFIG_DIR}")
 
 
@@ -159,33 +224,19 @@ def migrate_data():
     Data directory contains a directory Steam which contains all installed
     games and is massive. It needs to be separately moved
     """
-    source = os.path.expandvars("$XDG_DATA_HOME")
-    target = os.path.join(FLATPAK_STATE_DIR, DEFAULT_DATA_DIR)
-    backup = f'{target}.bak'
-    relocated = os.path.expandvars("$XDG_DATA_HOME.old")
-    steam_root_source = os.path.join(source, "Steam")
-    steam_root_target = os.path.join(target, "Steam")
-    if not os.path.islink(source):
-        if os.path.isdir(target):
-            copytree(target, backup, ignore=[steam_root_target])
-        copytree(source, target, ignore=[steam_root_source])
-        if os.path.isdir(steam_root_source):
-            os.rename(steam_root_source, steam_root_target)
-        os.rename(source, relocated)
-        symlink_rel(target, source)
-    else:
-        if os.path.isdir(relocated):
-            shutil.rmtree(relocated)
+    migrator = Migrator(os.path.expandvars("$XDG_DATA_HOME"),
+                        os.path.join(FLATPAK_STATE_DIR, DEFAULT_DATA_DIR),
+                        two_steps=True,
+                        rename=["Steam"])
+    migrator.apply()
     os.environ["XDG_DATA_HOME"] = os.path.expandvars(f"$HOME/{DEFAULT_DATA_DIR}")
 
 
 def migrate_cache():
-    source = os.path.expandvars("$XDG_CACHE_HOME")
-    target = os.path.join(FLATPAK_STATE_DIR, DEFAULT_CACHE_DIR)
-    if not os.path.islink(source):
-        copytree(source, target)
-        shutil.rmtree(source)
-        symlink_rel(target, source)
+    migrator = Migrator(os.path.expandvars("$XDG_CACHE_HOME"),
+                        os.path.join(FLATPAK_STATE_DIR, DEFAULT_CACHE_DIR),
+                        need_backup=False)
+    migrator.apply()
     os.environ["XDG_CACHE_HOME"] = os.path.expandvars(f"$HOME/{DEFAULT_CACHE_DIR}")
 
 
@@ -211,7 +262,8 @@ def configure_shared_library_guard():
 
 def main(steam_binary=STEAM_PATH):
     os.chdir(os.environ["HOME"]) # Ensure sane cwd
-    print ("https://github.com/flathub/com.valvesoftware.Steam/wiki")
+    logging.basicConfig(level=logging.DEBUG)
+    logging.info("https://github.com/flathub/com.valvesoftware.Steam/wiki")
     current_info = read_flatpak_info(FLATPAK_INFO)
     check_allowed_to_run(current_info)
     migrate_config()


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
Essentially this just merges three distinct functions in one method.
Additionally, it replaces `print()`s with logging, spitting out more messages about what this script is going to do while not printing a message on each copied file.