### PR TITLE
Enable controller support

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -18,6 +18,7 @@ finish-args:
   - --socket=wayland
   - --socket=x11
   - --socket=pulseaudio
+  - --socket=system-bus
   - --share=network
   - --talk-name=org.gnome.SettingsDaemon.MediaKeys
   # Steam in -steamos mode uses Network Manager for network settings, e.g.


### PR DESCRIPTION
This commit enables flatpak's system-bus socket for Steam, which allows
Steam to talk to a controller.

Fixes issue #699.

<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
