### PR TITLE
eudev: update to 3.2.10 and switch to official tarball

### DIFF
--- a/sources/eudev-archive.json
+++ b/sources/eudev-archive.json
@@ -1,5 +1,5 @@
 {
   "type": "archive",
-  "url": "https://github.com/gentoo/eudev/archive/v3.2.9.tar.gz",
-  "sha256": "7d281276b480da3935d1acb239748c2c9db01a8043aad7e918ce57a223d8cd24"
+  "url": "https://dev.gentoo.org/~blueness/eudev/eudev-3.2.10.tar.gz",
+  "sha256": "87bb028d470fd1b85169349b44c55d5b733733dc2d50ddf1196e026725ead034"
 }


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
