### PR TITLE
Fix environment variable masking with flatpak 1.10+

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -40,6 +40,7 @@ finish-args:
   - --allow=bluetooth
   - --persist=.
   - --env=TZ=
+  - --unset-env=TZ
   - --env=LC_ADDRESS=C
   - --env=LC_COLLATE=C
   - --env=LC_MONETARY=C
@@ -48,12 +49,17 @@ finish-args:
   - --env=LC_NUMERIC=C
   - --env=LC_TELEPHONE=C
   - --env=ALSA_CONFIG_PATH=
+  - --unset-env=ALSA_CONFIG_PATH
   - --env=MESA_GLSL_CACHE_DIR=
+  - --unset-env=MESA_GLSL_CACHE_DIR
   - --env=STEAM_RUNTIME_PREFER_HOST_LIBRARIES=
+  - --unset-env=STEAM_RUNTIME_PREFER_HOST_LIBRARIES
   - --env=STEAM_RUNTIME=
+  - --unset-env=STEAM_RUNTIME
   - --env=FLATPAK_STEAM_XDG_DIRS_PREFIX=~/.var/app/com.valvesoftware.Steam
   - --env=FLATPAK_STEAM_UPDATE_SYMLINKS=0
   - --env=SDL_VIDEODRIVER=
+  - --unset-env=SDL_VIDEODRIVER
   - --env=DBUS_FATAL_WARNINGS=0
   - --env=SSL_CERT_DIR=/etc/ssl/certs
   - --env=STEAM_EXTRA_COMPAT_TOOLS_PATHS=/app/share/steam/compatibilitytools.d


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
There's several environment variables which if leaked from host can break apps. Flatpak 1.10 has a behavioural change such that setting variables empty no longer removes them from environment but instead creates empty environment variables. We need to support both old and new flatpak so manifest needs to clear the variables in both old and new way.

Fixes https://github.com/flathub/com.valvesoftware.Steam/issues/729 https://github.com/flathub/com.valvesoftware.Steam/issues/708