### PR TITLE
Fix metainfo updating

### DIFF
--- a/com.valvesoftware.Steam.metainfo.xml
+++ b/com.valvesoftware.Steam.metainfo.xml
@@ -47,6 +47,7 @@
     <value key="GnomeSoftware::popular-background">https://raw.githubusercontent.com/flathub/com.valvesoftware.Steam/master/images/com.valvesoftware.Steam-thumb.png</value>
   </metadata>
   <releases>
+    <release version="1.0.0.69" date="2021-03-03"/>
     <release version="1.0.0.68" date="2020-12-02"/>
     <release version="1.0.0.67" date="2020-11-20"/>
     <release version="1.0.0.66" date="2020-07-29"/>

--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -183,6 +183,7 @@ modules:
         sha256: 6f9838014a6b13f953ba726ce7d203946bb93bfd5d074901bc216ad04ab2c767
         x-checker-data:
           type: html
+          is-main-source: true
           url: http://repo.steampowered.com/steam/archive/precise/
           version-pattern: steam_([\d.-]+).tar.gz
           url-pattern: (steam_[\d.-]+.tar.gz)

--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -185,8 +185,7 @@ modules:
           type: html
           is-main-source: true
           url: http://repo.steampowered.com/steam/archive/precise/
-          version-pattern: steam_([\d.-]+).tar.gz
-          url-pattern: (steam_[\d.-]+.tar.gz)
+          pattern: (steam_([\d.-]+).tar.gz)
       - type: file
         path: com.valvesoftware.Steam.metainfo.xml
 


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
flatpak-external-data-checker guesses that the last source in the manifest is the main one, which is wrong in our case, so we should explicitly mark the Steam source as main.