### PR TITLE
Look for updates via preferred URL

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -179,12 +179,12 @@ modules:
         ln -sfr $(readlink -f /app/share/applications/steam.desktop) /app/share/applications/steam.desktop
     sources:
       - type: archive
-        url: http://repo.steampowered.com/steam/archive/precise/steam_1.0.0.69.tar.gz
+        url: https://repo.steampowered.com/steam/archive/beta/steam_1.0.0.69.tar.gz
         sha256: 6f9838014a6b13f953ba726ce7d203946bb93bfd5d074901bc216ad04ab2c767
         x-checker-data:
           type: html
           is-main-source: true
-          url: http://repo.steampowered.com/steam/archive/precise/
+          url: https://repo.steampowered.com/steam/archive/beta/
           pattern: (steam_([\d.-]+).tar.gz)
       - type: file
         path: com.valvesoftware.Steam.metainfo.xml


### PR DESCRIPTION
For historical reasons http://repo.steampowered.com/steam/archive/precise
receives all updates to the Steam client (either beta or stable),
but the preferred archive directories are now steam/archive/beta
(all versions, either beta or stable) and steam/archive/stable
(just the releases that have been promoted from beta to stable).

While we're here, use https to download it.