### PR TITLE
Use preferred URL

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -179,12 +179,12 @@ modules:
         ln -sfr $(readlink -f /app/share/applications/steam.desktop) /app/share/applications/steam.desktop
     sources:
       - type: archive
-        url: http://repo.steampowered.com/steam/archive/precise/steam_1.0.0.70.tar.gz
+        url: https://repo.steampowered.com/steam/archive/stable/steam_1.0.0.70.tar.gz
         sha256: 9ff88a5778c7b00efb18f324d4cd0c282d5f438dad1201bc3e9822e3ff6a2dff
         x-checker-data:
           type: html
           is-main-source: true
-          url: http://repo.steampowered.com/steam/archive/precise/
+          url: https://repo.steampowered.com/steam/archive/stable/
           pattern: (steam_([\d.-]+).tar.gz)
       - type: file
         path: com.valvesoftware.Steam.metainfo.xml


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
For historical reasons http://repo.steampowered.com/steam/archive/precise
receives all updates to the Steam client (either beta or stable),
but the preferred archive directories are now steam/archive/beta
(all versions, either beta or stable) and steam/archive/stable
(just the releases that have been promoted from beta to stable).

While we're here, use https to download it.
Ported from https://github.com/flathub/com.valvesoftware.Steam/pull/739