### PR TITLE
Make Proton extension autoinstalled

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -117,6 +117,12 @@ add-extensions:
     no-autodownload: true
     autodelete: false
 
+  com.valvesoftware.Steam.CompatibilityTool.Proton:
+    directory: share/steam/compatibilitytools.d/Proton
+    version: beta
+    versions: beta;test
+    autodelete: true
+
   com.valvesoftware.Steam.CompatibilityTool:
     subdirectories: true
     directory: share/steam/compatibilitytools.d
@@ -233,7 +239,7 @@ modules:
         install -Dm644 -t /app/etc ld.so.conf
         shared-library-guard-config-converter blocklist/* --outfile /app/etc/freedesktop-sdk.ld.so.blockedlist
         mkdir -p /app/lib{,32}/ffmpeg
-        mkdir -p /app/share/steam/compatibilitytools.d
+        mkdir -p /app/share/steam/compatibilitytools.d/Proton
         mkdir -p /app/utils /app/share/vulkan
         ln -srv /app/{utils/,}share/vulkan/explicit_layer.d
         ln -srv /app/{utils/,}share/vulkan/implicit_layer.d


### PR DESCRIPTION
Completely untested! But seems to work.

The idea is to create an additional extension point dedicated for Proton, with the same mount point, but matching its full ID without subdirectories. Its only purpose is to make flatpak autodownload the extension while keeping other compatibility tools optional.

`com.valvesoftware.Steam.CompatibilityTool.Proton` will match both extension points and be enabled twice, first time as normal and second time mounted over itself (I believe we don't care about order).

<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
