### PR TITLE
Use relative symlinks in /app/links/lib

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -239,8 +239,8 @@ modules:
         ln -srv /app/{utils/,}share/vulkan/explicit_layer.d
         ln -srv /app/{utils/,}share/vulkan/implicit_layer.d
         mkdir -p /app/links/lib
-        ln -s /app/lib /app/links/lib/x86_64-linux-gnu
-        ln -s /app/lib32 /app/links/lib/i386-linux-gnu
+        ln -srv /app/lib /app/links/lib/x86_64-linux-gnu
+        ln -srv /app/lib32 /app/links/lib/i386-linux-gnu
     sources:
       - type: dir
         path: resources


### PR DESCRIPTION
When creating a new container with the new Flatpak sub-sandbox feature,
the original `/app` directory is binded as `/run/parent/app`.
But if we use absolute symlinks in `.../app/links/lib`, they will end up
being broken inside the new container because there `/app/lib` and
`/app/lib32` don't exist.

