### PR TITLE
Drop network manager permission

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -20,10 +20,6 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
   - --talk-name=org.gnome.SettingsDaemon.MediaKeys
-  # Steam in -steamos mode uses Network Manager for network settings, e.g.
-  # connecting to wifi and so on.
-  # In normal mode, it probably just gets info about current connection status.
-  - --system-talk-name=org.freedesktop.NetworkManager
   # Wine uses UDisks2 to enumerate disk drives
   - --system-talk-name=org.freedesktop.UDisks2
   - --talk-name=org.kde.StatusNotifierWatcher


### PR DESCRIPTION
This seems to be really wide and if system policies are not set
properly, it might allow access to eg WiFi passwords.

It can also result in admin password prompts when policies are
properly which isn't any more desirable.

<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
