### PR TITLE
Revert "Drop network manager permission"

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -20,6 +20,10 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
   - --talk-name=org.gnome.SettingsDaemon.MediaKeys
+  # Steam in -steamos mode uses Network Manager for network settings, e.g.
+  # connecting to wifi and so on.
+  # In normal mode, it probably just gets info about current connection status.
+  - --system-talk-name=org.freedesktop.NetworkManager
   # Wine uses UDisks2 to enumerate disk drives
   - --system-talk-name=org.freedesktop.UDisks2
   - --talk-name=org.kde.StatusNotifierWatcher


### PR DESCRIPTION
This reverts commit 23429eb8499b4ba177faafdec16e15c539f020bb.

It appears that cutting off Steam Client from NetworkManager DBus API
causes a startup delay, see ValveSoftware/steam-for-linux#4979

<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
