### PR TITLE
Add `VulkanLayer` extensions bindirs to `PATH`

### DIFF
--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -45,9 +45,9 @@ def read_flatpak_info(path):
         "app-extensions": dict((s.split("=")
                                 for s in flatpak_info.get("Instance", "app-extensions",
                                                           fallback="").split(";") if s)),
-        "runtime-extensions": flatpak_info.get("Instance",
-                                               "runtime-extensions",
-                                               fallback=None),
+        "runtime-extensions": dict((s.split("=")
+                                   for s in flatpak_info.get("Instance", "runtime-extensions",
+                                                             fallback="").split(";") if s)),
         "filesystems": flatpak_info.get("Context", "filesystems",
                                         fallback="").split(";")
     }


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
Since MangoHud migrated to runtime extension, `mangohud` command is uawailable any more in Steam flatpak sandbox (see https://github.com/flathub/org.freedesktop.Platform.VulkanLayer.MangoHud/issues/1#issuecomment-923994885).

To fix this, append each `.VulkanLayer` extension `bin` subdir to `PATH` via our wrapper.

Closes #811 