### PR TITLE
Add vulkan extensions share dir to XDG_DATA_DIRS

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -68,6 +68,7 @@ finish-args:
   - --env=PYTHONPATH=/app/utils/lib/python3.8/site-packages
   - --env=PROTON_DEBUG_DIR=/var/tmp
   - --env=XDG_CONFIG_DIRS=/etc/xdg:/usr/lib/x86_64-linux-gnu/GL:/usr/lib/i386-linux-gnu/GL
+  - --env=XDG_DATA_DIRS=/app/share:/usr/lib/extensions/vulkan/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share
   - --env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/app/lib32/gstreamer-1.0:/usr/lib/extensions/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0:/usr/lib/i386-linux-gnu/gstreamer-1.0
   - --require-version=1.0.0
 


### PR DESCRIPTION
vulkan-loader in freedesktop-sdk is patched to look for vulkan layer in the extension dirs, but pressure-vessel doesn't know that, and doesn't look in that path. We can workaround this by adding the path to `XDG_DATA_DIRS`, in which pressure-vessel does look.

This could be better solved in freedesktop-sdk or pressure-vessel, but I think for now we can apply this workaround on the flatpak app side.

Fixes #821 