### PR TITLE
Sync metainfo with upstream and add external game library notice

### DIFF
--- a/com.valvesoftware.Steam.metainfo.xml
+++ b/com.valvesoftware.Steam.metainfo.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2017 Cosimo Cecchi <cosimoc@gnome.org> -->
-<application>
-  <id type="desktop">com.valvesoftware.Steam.desktop</id>
+<!-- Copyright 2017 Cosimo Cecchi -->
+<!-- Copyright 2021 Collabora Ltd. -->
+<component type="desktop-application">
+  <id>com.valvesoftware.Steam.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Steam</name>
   <summary>Manage and play games distributed by Steam</summary>
@@ -96,4 +97,4 @@
     <content_attribute id="money-purchasing">intense</content_attribute>
     <content_attribute id="money-gambling">intense</content_attribute>
   </content_rating>
-</application>
+</component>

--- a/com.valvesoftware.Steam.metainfo.xml
+++ b/com.valvesoftware.Steam.metainfo.xml
@@ -96,5 +96,4 @@
     <content_attribute id="money-purchasing">intense</content_attribute>
     <content_attribute id="money-gambling">intense</content_attribute>
   </content_rating>
-  <update_contact>tingping_AT_fedoraproject.org</update_contact>
 </application>

--- a/com.valvesoftware.Steam.metainfo.xml
+++ b/com.valvesoftware.Steam.metainfo.xml
@@ -11,6 +11,9 @@
   <description>
     <p>Steam is a software distribution service with an online store, automated installation, automatic updates, achievements, SteamCloud synchronized savegame and screenshot functionality, and many social features.</p>
     <p>Note: This is a community package of Steam gaming plaform not officially supported by Valve. Report bugs through linked issue tracker.</p>
+    <p>Note: To add a game library on another drive, first you need to grant the app access to it:</p>
+    <!-- Sadly GNOME Software as of v40 doesn't support <em> or <code> -->
+    <p>flatpak override --user --filesystem=/path/to/your/Steam/Library com.valvesoftware.Steam</p>
     <p>Note: You need Flatpak version 1.12 or later to be able to run Proton 5.13 and newer.</p>
   </description>
   <description xml:lang="pt_BR">

--- a/com.valvesoftware.Steam.metainfo.xml
+++ b/com.valvesoftware.Steam.metainfo.xml
@@ -3,7 +3,6 @@
 <application>
   <id type="desktop">com.valvesoftware.Steam.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <translation type="gettext">Valve Corporation</translation>
   <name>Steam</name>
   <summary>Manage and play games distributed by Steam</summary>
   <summary xml:lang="pt_BR">Jogue jogos populares e os últimos lançamentos</summary>

--- a/com.valvesoftware.Steam.metainfo.xml
+++ b/com.valvesoftware.Steam.metainfo.xml
@@ -5,13 +5,12 @@
   <id>com.valvesoftware.Steam.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Steam</name>
-  <summary>Manage and play games distributed by Steam</summary>
+  <summary>Launcher for the Steam software distribution service</summary>
   <summary xml:lang="pt_BR">Jogue jogos populares e os últimos lançamentos</summary>
   <summary xml:lang="es">Juega a los juegos populares y los últimos lanzamientos</summary>
   <description>
-    <p>This is a community package of Steam gaming plaform not officially supported by Valve. Report bugs through linked issue tracker.</p>
-    <p>Steam is a popular platform for buying, downloading, and playing video games, and chatting with other players.</p>
-    <p>Many games require an online purchase, but some popular games, such as Team Fortress 2, are free to play. When searching in the store, be sure to narrow results by the SteamOS/Linux operating system. Not all Linux games are compatible with your system, so make sure you check the requirements before purchasing games.</p>
+    <p>Steam is a software distribution service with an online store, automated installation, automatic updates, achievements, SteamCloud synchronized savegame and screenshot functionality, and many social features.</p>
+    <p>Note: This is a community package of Steam gaming plaform not officially supported by Valve. Report bugs through linked issue tracker.</p>
     <p>Note: You need Flatpak version 1.12 or later to be able to run Proton 5.13 and newer.</p>
   </description>
   <description xml:lang="pt_BR">


### PR DESCRIPTION
Diverge less from the upstream metainfo.

Also adds a suggestion how to allow access to a game library on an external drive, as discussed on Matrix.