### PR TITLE
Allow all extension branches

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -122,16 +122,16 @@ add-extensions:
   com.valvesoftware.Steam.CompatibilityTool:
     subdirectories: true
     directory: share/steam/compatibilitytools.d
-    version: beta
-    versions: beta;test
+    version: stable
+    versions: stable;beta;test
     no-autodownload: true
     autodelete: true
 
   com.valvesoftware.Steam.Utility:
     subdirectories: true
     directory: utils
-    version: beta
-    versions: beta;test
+    version: stable
+    versions: stable;beta;test
     add-ld-path: lib
     merge-dirs: bin;lib/python3.8/site-packages;share/vulkan/explicit_layer.d;share/vulkan/implicit_layer.d;
     no-autodownload: true


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
Installing and running Steam from `beta` branch to get Proton from `beta` branch is really inconvenient. 