### PR TITLE
Fix downloading and mounting the VAAPI.Intel.i386 extension

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -98,12 +98,11 @@ add-extensions:
     directory: lib/i386-linux-gnu/dri/intel-vaapi-driver
     version: '21.08'
     versions: '21.08'
-    subdirectories: true
-    no-autodownload: true
     autodelete: false
+    no-autodownload: true
     add-ld-path: lib
-    download-if: active-gl-driver
-    enable-if: active-gl-driver
+    download-if: have-intel-gpu
+    autoprune-unless: have-intel-gpu
 
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg


### PR DESCRIPTION
From the commit message:
```
This change aligns org.freedesktop.Platform.VAAPI.Intel.i386 to how
org.freedesktop.Platform.VAAPI.Intel is configured in the Platform
runtime.

It seems that the previous configuration meant that it was effectively
never mounted. This should enable 32-bit VAAPI to work with Intel GPUs.
```
