### PR TITLE
Check input device permissions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,3 @@
 [MESSAGES CONTROL]
 disable=logging-fstring-interpolation
+extension-pkg-allow-list=posix1e

--- a/python3-requirements.json
+++ b/python3-requirements.json
@@ -54,6 +54,20 @@
                     "sha256": "68c1a125cc49e343d535af2dd25074e9cb0908c6607f073947c4a04bbe234534"
                 }
             ]
+        },
+        {
+            "name": "python3-pylibacl",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pylibacl\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/09/23/ad116ac73a352ef82dba4c0a7b0536ed7b5071bd48227c211b745adcc468/pylibacl-0.6.0.tar.gz",
+                    "sha256": "88a0a4322e3a62d797d61f96ec7f38d1c471c48a3cc3cedb32ab5c20aa98d9ff"
+                }
+            ]
         }
     ]
 }

--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -11,8 +11,9 @@ import typing as t
 import logging
 
 
+FLATPAK_ID = os.getenv("FLATPAK_ID", "com.valvesoftware.Steam")
 STEAM_PATH = "/app/bin/steam"
-FLATPAK_STATE_DIR = os.path.expandvars("$HOME/.var/app/com.valvesoftware.Steam")
+FLATPAK_STATE_DIR = os.path.expanduser(f"~/.var/app/{FLATPAK_ID}")
 XDG_DATA_HOME = os.environ["XDG_DATA_HOME"]
 XDG_CACHE_HOME = os.environ["XDG_CACHE_HOME"]
 XDG_RUNTIME_DIR = os.environ["XDG_RUNTIME_DIR"]
@@ -41,6 +42,7 @@ EXTENSIONS = {
         },
     },
 }
+WIKI_URL = f"https://github.com/flathub/{FLATPAK_ID}/wiki"
 
 
 def read_flatpak_info(path):
@@ -143,8 +145,7 @@ def check_bad_filesystem_entries(entries):
             logging.warning(f"Bad item \"{items[0]}\" found in filesystem overrides")
             found = True
     if found:
-        faq = ("https://github.com/flathub/com.valvesoftware.Steam/wiki"
-               "#i-want-to-add-external-disk-for-steam-libraries")
+        faq = f"{WIKI_URL}#i-want-to-add-external-disk-for-steam-libraries"
         raise SystemExit(f"Please see {faq}")
 
 
@@ -383,7 +384,7 @@ def configure_shared_library_guard():
 def main(steam_binary=STEAM_PATH):
     os.chdir(os.environ["HOME"]) # Ensure sane cwd
     logging.basicConfig(level=logging.DEBUG)
-    logging.info("https://github.com/flathub/com.valvesoftware.Steam/wiki")
+    logging.info(WIKI_URL)
     current_info = read_flatpak_info(FLATPAK_INFO)
     check_allowed_to_run(current_info)
     should_update_symlinks = env_is_true(os.environ.get("FLATPAK_STEAM_UPDATE_SYMLINKS", "0"))


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
Do an educated guess if proper udev rules are installed on host by checking ACL on `/dev/uinput`, and warn the user (just once) if they don't seem to be installed.