### PR TITLE
Check /dev/uinput exists before checking permissions

### DIFF
--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -125,12 +125,14 @@ def read_file(path):
 def check_device_perms():
     has_perms = False
     logging.debug("Checking input devices permissions")
-    for entry in posix1e.ACL(file="/dev/uinput"):
-        if (entry.tag_type == posix1e.ACL_USER
-            and entry.qualifier == os.geteuid()
-            and entry.permset.write):
-            has_perms = True
-            break
+    uinput_path = Path("/dev/uinput")
+    if uinput_path.exists():
+        for entry in posix1e.ACL(file=uinput_path):
+            if (entry.tag_type == posix1e.ACL_USER
+                and entry.qualifier == os.geteuid()
+                and entry.permset.write):
+                has_perms = True
+                break
     if not has_perms:
         MSG_NO_INPUT_DEV_PERMS.show()
     return has_perms

--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -126,13 +126,14 @@ def check_device_perms():
     has_perms = False
     logging.debug("Checking input devices permissions")
     uinput_path = Path("/dev/uinput")
-    if uinput_path.exists():
-        for entry in posix1e.ACL(file=uinput_path):
-            if (entry.tag_type == posix1e.ACL_USER
-                and entry.qualifier == os.geteuid()
-                and entry.permset.write):
-                has_perms = True
-                break
+    if not uinput_path.exists():
+        return None
+    for entry in posix1e.ACL(file=uinput_path):
+        if (entry.tag_type == posix1e.ACL_USER
+            and entry.qualifier == os.geteuid()
+            and entry.permset.write):
+            has_perms = True
+            break
     if not has_perms:
         MSG_NO_INPUT_DEV_PERMS.show()
     return has_perms


### PR DESCRIPTION
When devices=!all on flatpak overrides, /dev/uinput doesn't exist, which causes a crash when checking permissions.

```
Traceback (most recent call last):
  File "/app/bin/steam-wrapper", line 8, in <module>
    sys.exit(main())
  File "/app/lib/python3.9/site-packages/steam_wrapper.py", line 463, in main
    check_device_perms()
  File "/app/lib/python3.9/site-packages/steam_wrapper.py", line 128, in check_device_perms
    for entry in posix1e.ACL(file="/dev/uinput"):
FileNotFoundError: [Errno 2] No such file or directory: '/dev/uinput'
```
