### PR TITLE
wrapper: Run Steam with -no-cef-sandbox

### DIFF
--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -440,6 +440,7 @@ def configure_shared_library_guard():
 
 def main(steam_binary=STEAM_PATH):
     os.chdir(os.environ["HOME"]) # Ensure sane cwd
+    argv = [sys.argv[0], '-no-cef-sandbox'] + sys.argv[1:]
     logging.basicConfig(level=logging.DEBUG)
     logging.info(WIKI_URL)
     current_info = read_flatpak_info(FLATPAK_INFO)
@@ -457,7 +458,7 @@ def main(steam_binary=STEAM_PATH):
     should_restart += migrate_data(current_info, xdg_dirs_prefix)
     should_restart += migrate_cache(current_info, xdg_dirs_prefix)
     if should_restart:
-        command = ["/usr/bin/flatpak-spawn"] + sys.argv
+        command = ["/usr/bin/flatpak-spawn"] + argv
         logging.info("Restarting app due to finalize sandbox tuning")
         os.execv(command[0], command)
     else:
@@ -468,4 +469,4 @@ def main(steam_binary=STEAM_PATH):
         configure_shared_library_guard()
         enable_extensions(current_info)
         enable_discord_rpc()
-        os.execv(steam_binary, [steam_binary] + sys.argv[1:])
+        os.execv(steam_binary, [steam_binary] + argv[1:])


### PR DESCRIPTION
Recent Steam betas enable the CEF sandbox by default, which cannot work
inside a Flatpak sandbox, since it relies on the ability to create new
user namespaces, which Flatpak doesn't allow (because a malicious or
compromised app could use a new user namespace to manipulate its mount
namespace and trick IPC servers into treating it as non-sandboxed,
similar to CVE-2021-41133).

As a short-term solution for this, disable the sandbox again. For users
of the default (general availability) branch of Steam, this option is
accepted but doesn't make any practical difference; for users of the
beta branch, this returns to the behaviour of the default branch.

Partially addresses:
https://github.com/ValveSoftware/steam-for-linux/issues/8373