### PR TITLE
Fix typos

### DIFF
--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -74,9 +74,9 @@ MSG_NO_INPUT_DEV_PERMS = Message(
     "Missing permissions for input devices",
     (
         "Steam input devices udev rules don't seem to be installed.\n"
-        "If you expirience issues with gamepads, consider installing\n"
-        "\"steam-devices\" package using your distro package manager.\n"
-        "See the Steam flatpak "
+        "If you experience issues with gamepads, consider installing\n"
+        "\"steam-devices\" package using your distribution package manager.\n"
+        "See the Steam Flatpak application "
         f"<a href=\"{WIKI_URL}#my-controller-isnt-being-detected\">wiki</a> "
         "for more details."
     ),


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->

This MR fixes some typos and is more formal.

FTR, the official term is "Flatpak application" and not "flatpak" or "flatpaks", per the [Flatpak docs](https://docs.flatpak.org/en/latest/introduction.html#:~:text=flatpak%20application%3A%20these%20are%20the%20applications%20the%20user%20installs%20via%20the%20flatpak%20command%20or%20via%20a%20different%20ui%20like%20gnome%20software%20or%20kde%20discover.).