### PR TITLE
Replace x11 by x11-fallback

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -16,7 +16,7 @@ sdk-extensions:
 finish-args:
   - --share=ipc
   - --socket=wayland
-  - --socket=x11
+  - --socket=x11-fallback
   - --socket=pulseaudio
   - --share=network
   - --talk-name=org.gnome.SettingsDaemon.MediaKeys


### PR DESCRIPTION
AFAIK it should work the same. It only falls back on non-Wayland systems on X11 then, which should be fine.

See/Fixes https://github.com/flathub/com.valvesoftware.Steam/issues/901

<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
