### PR TITLE
Remove lsb_release from app

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -209,15 +209,6 @@ modules:
       - type: file
         path: com.valvesoftware.Steam.cmd.metainfo.xml
 
-  - name: lsb-release-compat
-    buildsystem: simple
-    build-commands:
-      - make install PREFIX=/app
-    sources:
-      - type: git
-        url: https://gitlab.com/nanonyme/lsb-release-compat.git
-        commit: f4f908b62dcc9cd081eb2a42b6ad7cf98db4bb10
-
   - name: platform-bootstrap
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
Looks like Steam can now read os-release directly so remove the
indirection

<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
