### PR TITLE
Block libstdc++ for Worms W.M.D

### DIFF
--- a/resources/blocklist/worms_wmd.yml
+++ b/resources/blocklist/worms_wmd.yml
@@ -1,0 +1,7 @@
+entries:
+  - basedir: "*(/*|/.*)/WormsWMD"
+    blocklists:
+      - binaries:
+          - path: "Worms W.M.Dx64"
+        libraries:
+          - path: libstdc++.so.6


### PR DESCRIPTION
The game appears to bundle an incompatible version of libstdc++. Without
the blacklisting I get:

```
.../.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/WormsWMD/Worms W.M.Dx64: .../.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/WormsWMD/lib/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by /usr/lib/x86_64-linux-gnu/libicuuc.so.71)
```