### PR TITLE
Fix libdir for Worms W.M.D blacklist

### DIFF
--- a/resources/blocklist/worms_wmd.yml
+++ b/resources/blocklist/worms_wmd.yml
@@ -3,5 +3,6 @@ entries:
     blocklists:
       - binaries:
           - path: "Worms W.M.Dx64"
+            libdir: lib
         libraries:
           - path: libstdc++.so.6


### PR DESCRIPTION
My previous PR (#949) omitted the `/lib/` component of the path to `libstdc++.so.6`.