### PR TITLE
wrapper: Check effective perms on uinput device

### DIFF
--- a/python3-requirements.json
+++ b/python3-requirements.json
@@ -54,20 +54,6 @@
                     "sha256": "68c1a125cc49e343d535af2dd25074e9cb0908c6607f073947c4a04bbe234534"
                 }
             ]
-        },
-        {
-            "name": "python3-pylibacl",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pylibacl\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/09/23/ad116ac73a352ef82dba4c0a7b0536ed7b5071bd48227c211b745adcc468/pylibacl-0.6.0.tar.gz",
-                    "sha256": "88a0a4322e3a62d797d61f96ec7f38d1c471c48a3cc3cedb32ab5c20aa98d9ff"
-                }
-            ]
         }
     ]
 }

--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -12,8 +12,6 @@ import typing as t
 import logging
 import subprocess
 
-import posix1e
-
 
 FLATPAK_ID = os.getenv("FLATPAK_ID", "com.valvesoftware.Steam")
 STEAM_PATH = "/app/bin/steam"
@@ -140,17 +138,11 @@ def read_file(path):
 
 
 def check_device_perms():
-    has_perms = False
     logging.debug("Checking input devices permissions")
     uinput_path = Path("/dev/uinput")
     if not uinput_path.exists():
         return None
-    for entry in posix1e.ACL(file=uinput_path):
-        if (entry.tag_type == posix1e.ACL_USER
-            and entry.qualifier == os.geteuid()
-            and entry.permset.write):
-            has_perms = True
-            break
+    has_perms = os.access(uinput_path, os.R_OK | os.W_OK)
     if not has_perms:
         MSG_NO_INPUT_DEV_PERMS.show()
     return has_perms


### PR DESCRIPTION
I've realized my initial perms check implementation was flawed: not all systems use ACL to set up input device perms (causing issues like #965), and the check can be made in a much simpler way by just checking effective perms (i.e. if the current user can open the device in r/w mode). Let's hope I'm not missing something.
Fixes #965 