### PR TITLE
add env to make (some) appimages run

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -22,6 +22,8 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
   - --talk-name=org.gnome.SettingsDaemon.MediaKeys
+  # Needed for appimages
+  - --env=APPIMAGE_EXTRACT_AND_RUN=1
   # Steam in -steamos mode uses Network Manager for network settings, e.g.
   # connecting to wifi and so on.
   # In normal mode, it probably just gets info about current connection status.


### PR DESCRIPTION
With this, appimages can now run, some will need new deps added to run (like https://github.com/flathub/net.lutris.Lutris/issues/299), some will need some arguments added to run (like `--no-sandbox` for electron appimages), but it's better that having appimages not working at all.

Fixes: https://github.com/flathub/com.valvesoftware.Steam/issues/770