### PR TITLE
add Mumble overlay support

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -35,8 +35,10 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --filesystem=xdg-music:ro
   - --filesystem=xdg-pictures:ro
+  - --filesystem=xdg-run/mumble:create
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --device=all
+  - --device=shm
   - --allow=multiarch
   - --allow=devel
   - --allow=bluetooth


### PR DESCRIPTION
adds access to `$XDG_RUNTIME_DIR/mumble` in order to allow Mumble overlay in games installed with flatpak'ed Steam.
Shared memory is required as well, so I added `--device=shm` as, to my testing, it is not included in `--device=all`

Fixes: #997
Depends on: https://github.com/mumble-voip/mumble/pull/5961

It's worth noting that this PR is not enough for having the overlay on Steam. An user has to manually copy overlay libraries in flatpak'ed Steam's directory because `/lib` and `/lib32` are not accessible. For example:

```bash
cp /usr/lib/mumble/libmumbleoverlay.x86.so /home/$USER/.var/app/com.valvesoftware.Steam/.local/share/Steam/linux32
```
and then proceed by setting the game launch options to:
```
LD_PRELOAD=~/.local/share/Steam/linux32/libmumbleoverlay.x86.so %command%
```