### PR TITLE
Add 22.08-extra to the GL32 extension point

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -2,7 +2,7 @@ app-id: com.valvesoftware.Steam
 runtime: org.freedesktop.Platform
 runtime-version: &runtime-version '22.08'
 x-gl-version: &gl-version '1.4'
-x-gl-versions: &gl-versions 22.08;1.4
+x-gl-versions: &gl-versions 22.08;22.08-extra;1.4
 sdk: org.freedesktop.Sdk
 command: steam-wrapper
 separate-locales: false


### PR DESCRIPTION
This allows the new Mesa extension with extra video codecs support to be mounted when installed.

CC: @nanonyme