### PR TITLE
Read-only access to Discord IPC socket directory

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -35,7 +35,7 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --filesystem=xdg-music:ro
   - --filesystem=xdg-pictures:ro
-  - --filesystem=xdg-run/app/com.discordapp.Discord:create
+  - --filesystem=xdg-run/app/com.discordapp.Discord:ro
   - --device=all
   - --allow=multiarch
   - --allow=devel


### PR DESCRIPTION
Write access is not required to connect to the socket. It's only required to create it, which is done by Discord.

<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
