### PR TITLE
wrapper: Better improper fs access handling

### DIFF
--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -9,6 +9,7 @@ import fnmatch
 import configparser
 from distutils.version import LooseVersion
 import typing as t
+import re
 import logging
 import subprocess
 
@@ -164,9 +165,9 @@ def check_bad_filesystem_entries(entries):
                  os.path.expandvars("/home/$USER")]
     found = False
     for entry in entries:
-        items = entry.split(";")
-        if items[0] in bad_names:
-            logging.warning(f"Bad item \"{items[0]}\" found in filesystem overrides")
+        item, _ = re.match(r"(.+?)(?:\:(\w+))?$", entry).groups()
+        if item in bad_names:
+            logging.warning(f"Bad item \"{item}\" found in filesystem overrides")
             found = True
     if found:
         faq = f"{WIKI_URL}#i-want-to-add-external-disk-for-steam-libraries"

--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -167,11 +167,16 @@ def check_bad_filesystem_entries(entries):
     for entry in entries:
         item, _ = re.match(r"(.+?)(?:\:(\w+))?$", entry).groups()
         if item in bad_names:
-            logging.warning(f"Bad item \"{item}\" found in filesystem overrides")
+            logging.warning(f"Found filesystem \"{entry}\" in static permissions")
             found = True
     if found:
-        faq = f"{WIKI_URL}#i-want-to-add-external-disk-for-steam-libraries"
-        raise SystemExit(f"Please see {faq}")
+        logging.error(
+            "Refusing to launch in order to prevent issues; "
+            "if you've added an override with access to some of the filesystems above, "
+            "please remove it and see "
+            f"{WIKI_URL}#i-want-to-add-external-disk-for-steam-libraries"
+        )
+        raise SystemExit(1)
 
 
 def check_allowed_to_run(current_info):


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
Properly strip off the access mode suffix (e.g. treat `home:ro` the same as `home`) and give a more explanatory message if unwanted filesystem access is detected.