### PR TITLE
Unbreak #1042 with empty filesystem entries

### DIFF
--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -165,7 +165,12 @@ def check_bad_filesystem_entries(entries):
                  os.path.expandvars("/home/$USER")]
     found = False
     for entry in entries:
-        item, _ = re.match(r"(.+?)(?:\:(\w+))?$", entry).groups()
+        if entry == '':
+            continue
+        matches = re.match(r"(.+?)(?:\:(\w+))?$", entry)
+        if matches is None:
+            continue
+        item, _ = matches.groups()
         if item in bad_names:
             logging.warning(f"Found filesystem \"{entry}\" in static permissions")
             found = True


### PR DESCRIPTION
The re introduced in #1042 doesn't necessarily match, and breaks launching Steam if a final ';' is present in the output of

    grep filesystem /var/lib/flatpak/app/com.valvesoftware.Steam/x86_64/beta/active/metadata


