### PR TITLE
Remove the use of org.freedesktop.Notification

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -28,7 +28,6 @@ finish-args:
   - --system-talk-name=org.freedesktop.UPower
   - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.freedesktop.PowerManagement
-  - --talk-name=org.freedesktop.Notifications
   - --filesystem=xdg-music:ro
   - --filesystem=xdg-pictures:ro
   - --filesystem=xdg-run/app/com.discordapp.Discord:create


### PR DESCRIPTION
Starting from libnotify 0.8, all calls go though the portal.