### PR TITLE
Use default GPU

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -180,6 +180,8 @@ modules:
         sed -i s:Exec=steam:Exec=/app/bin/steam-wrapper: steam.desktop
         sed -i s:/usr/bin/steam:/app/bin/steam-wrapper: steam.desktop
         desktop-file-edit --set-key=StartupWMClass --set-value=Steam steam.desktop
+        desktop-file-edit --remove-key=PrefersNonDefaultGPU steam.desktop
+        desktop-file-edit --remove-key=X-KDE-RunOnDiscreteGpu steam.desktop
         sed -i s:/usr/lib/:/app/lib/: steam
         PREFIX=/app make install
         ln -sf /bin/true /app/bin/steamdeps


### PR DESCRIPTION
The new Steam Big Picture Mode is now the default and it fails to start with the option to prefer a non-default GPU (usually a dGPU in a laptop). Now, the current beta branch has the same problem for Steam's main window due to using the same new graphical framework as the new BPM. Remove the option to avoid the issue.

There is no reason for the Steam app to wake-up a non-default GPU, only starting games should to do that. This setting was already bad before this issue.

Related to ValveSoftware/steam-for-linux#9383, ValveSoftware/steam-for-linux#9487, ValveSoftware/steam-for-linux#9190, ValveSoftware/steam-for-linux#8984, ValveSoftware/steam-for-linux#8381, ValveSoftware/steam-for-linux#9633, ValveSoftware/steam-for-linux#9641, ValveSoftware/steam-for-linux#9652

Resolves #1103, #1110

<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
