### PR TITLE
Refactor file ignore logic to be re-usable by streamcmd_wrapper

### DIFF
--- a/steam_wrapper/steamcmd_wrapper.py
+++ b/steam_wrapper/steamcmd_wrapper.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python3
-import steam_wrapper
 import os
+import shutil
+
+import steam_wrapper
+
 
 STEAMCMD_BOOTSTRAP_DIR = "/app/steamcmd"
 
@@ -15,13 +18,12 @@ def main():
 
     if not os.path.isfile(steamcmd_path):
         if os.path.isfile(os.path.join(STEAMCMD_BOOTSTRAP_DIR, "steamcmd.sh")):
-            steam_wrapper.copytree(
+            shutil.copytree.copytree(
                 STEAMCMD_BOOTSTRAP_DIR,
                 steamcmd_install_dir,
-                ignore=[
-                    os.path.join(STEAMCMD_BOOTSTRAP_DIR, p) for p in
-                    ['metadata', '.ref', 'share']
-                ]
+                symlinks=True,
+                ignore=steam_wrapper.FileIgnorer({'metadata', '.ref', 'share'},
+                dirs_exist_ok=True)
             )
         else:
             raise OSError("SteamCMD is not installed")


### PR DESCRIPTION
This allows us to just use standard library copytree in both wrappers. Fixes https://github.com/flathub/com.valvesoftware.Steam/issues/1028

<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
