### PR TITLE
Update steam-launcher 1.0.0.78

### DIFF
--- a/com.valvesoftware.Steam.metainfo.xml
+++ b/com.valvesoftware.Steam.metainfo.xml
@@ -58,6 +58,8 @@
     <value key="GnomeSoftware::popular-background">https://raw.githubusercontent.com/flathub/com.valvesoftware.Steam/master/images/com.valvesoftware.Steam-thumb.png</value>
   </metadata>
   <releases>
+    <release version="1.0.0.78" date="2023-05-09"/>
+    <release version="1.0.0.77" date="2023-05-09"/>
     <release version="1.0.0.76" date="2023-03-01"/>
     <release version="1.0.0.75" date="2022-07-12"/>
     <release version="1.0.0.74" date="2021-12-01"/>

--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -187,8 +187,8 @@ modules:
         install -Dm644 -t /app/share/metainfo com.valvesoftware.Steam.metainfo.xml
     sources:
       - type: archive
-        url: https://repo.steampowered.com/steam/archive/stable/steam_1.0.0.76.tar.gz
-        sha256: 5fb8b104ba1434b94c6e44373edfbb6188c8ef305f02bcd519b809f5e28f23fd
+        url: https://repo.steampowered.com/steam/archive/stable/steam_1.0.0.78.tar.gz
+        sha256: 104259755d7211b5f101db247ff70ebfed6ae6ca3e14da61195d1fbf91c7200d
         x-checker-data:
           type: html
           is-main-source: true


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->

steam-launcher 1.0.0.78 was promoted to general availability today.

I'm sending this PR to get a CI build, ~~I haven't tested this yet.~~ **Edit:** Tested the attached build, working fine.


### Changelog

```
steam (1:1.0.0.78) beta; urgency=medium

  * Specifically require gnome-terminal, konsole or xterm, and don't accept
    x-terminal-emulator. We require a terminal emulator that can be told to
    wait until the command it is running has exited, and that isn't the
    case for all x-terminal-emulator implementations, resulting in Steam
    trying to start before its dependencies have been installed, which will
    fail. (Reopens: steam-for-linux#9350)

 -- Simon McVittie   Tue, 09 May 2023 20:46:27 +0100

steam (1:1.0.0.77) beta; urgency=medium

  * Build using updated Steam client:
    - Client timestamp 1682708537 (2023-04-28)
    - Steam Runtime (scout) version 0.20230118.0
  * Update steam-devices subproject up to 2023-04-12:
    - steam-input: Add Razer Raiju Ultimate
      (steam-devices#31, thanks to @IAmTheRedSpy)
    - steam-input: Add Sony DualShock 3 (Playstation 3) controller
      (steam-devices#43, thanks to Jonatas Esteves)
    - steamvr: Provide access to Valve Index (28de:2102) serial port
      (steam-devices#44, thanks to Joshua Ashton)
  * Packaging:
    - Depend on Python 3.4.
      This was available in Debian since version 8 (EOL long ago), in Ubuntu
      since 14.04 (EOL), and in SteamOS 2 (EOL).
    - Depend on pkexec in preference to policykit-1, avoiding installation
      of a deprecated transitional package on Debian >= 12 and
      Ubuntu >= 22.04. Older versions that only have policykit-1 still work.
  * steamdeps installer script:
    - Turn off autoremovals when steamdeps runs apt, avoiding
      a failure to install dependencies if autoremovals were enabled
      system-wide (steam-for-linux#9350)
    - Accept any x-terminal-emulator as a terminal (steam-for-linux#9265)
    - Try harder to tell apt's conflict resolution heuristic
      that removing steam-launcher is not a good solution
      (followup for steam-for-linux#9301)
    - Remove compatibility with Python 3.2
    - Use shutil.which instead of which(1), for better efficiency and to
      avoid deprecation warnings in some versions
  * CI:
    - Test steamdeps on Ubuntu 16.04
    - Test steamdeps on Debian 12

 -- Simon McVittie   Tue, 09 May 2023 16:25:00 +0100
```