### PR TITLE
More refactoring to get src into scope for ignore function

### DIFF
--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -194,21 +194,19 @@ def check_allowed_to_run(current_info):
 
 
 class FileIgnorer:
-    def __init__(self, patterns: set):
+    def __init__(self, src: str, patterns: set):
+        assert not any(os.path.isabs(i) for i in patterns)
         self.patterns = patterns
-        assert not any(os.path.isabs(i) for i in self.patterns)
+        self.src = src
 
     def __call__(self, root: str, names: t.List[str]) -> t.Set[str]:
         ignored_names: t.Set[str] = set()
         for name in names:
             for ignored_pat in self.patterns:
                 if fnmatch.fnmatch(os.path.join(root, name),
-                                   os.path.join(src, ignored_pat)):
+                                   os.path.join(self.src, ignored_pat)):
                     ignored_names.add(name)
         return ignored_names
-
-    def __str__(self):
-        return str(self.patterns)
 
 
 class Migrator:
@@ -222,7 +220,7 @@ class Migrator:
         assert os.path.isabs(self.target)
         self.ignore = ignore or set()
         self.rename = rename or []
-        self.file_ignorer = FileIgnorer(self.ignore | set(self.rename))
+        self.no_copy = self.ignore | set(self.rename)
         self.two_steps = two_steps
         self.need_backup = need_backup
         self.target_backup = f'{self.target}.bak'
@@ -234,16 +232,17 @@ class Migrator:
         return not os.path.islink(self.source)
 
     def _copytree(self, src: str, dst: str):
-        shutil.copytree(src, dst, symlinks=True, ignore=self.file_ignorer, dirs_exist_ok=True)
+        file_ignorer = FileIgnorer(src, self.no_copy)
+        shutil.copytree(src, dst, symlinks=True, ignore=file_ignorer, dirs_exist_ok=True)
 
     def do_migrate(self):
         assert self.need_migration
         # Back-up target if requested
         if self.need_backup and os.path.isdir(self.target):
-            self.log.info(f"Copying {self.target} to {self.target_backup}, ignoring {self.file_ignorer}")
+            self.log.info(f"Copying {self.target} to {self.target_backup}, ignoring {self.no_copy}")
             self._copytree(self.target, self.target_backup)
         # Copy source to target, rename nocopy subdirs
-        self.log.info(f"Copying {self.source} to {self.target}, ignoring {self.file_ignorer}")
+        self.log.info(f"Copying {self.source} to {self.target}, ignoring {self.no_copy}")
         self._copytree(self.source, self.target)
         for rename_path in self.rename:
             if rename_path in self.ignore:

--- a/steam_wrapper/steamcmd_wrapper.py
+++ b/steam_wrapper/steamcmd_wrapper.py
@@ -18,12 +18,15 @@ def main():
 
     if not os.path.isfile(steamcmd_path):
         if os.path.isfile(os.path.join(STEAMCMD_BOOTSTRAP_DIR, "steamcmd.sh")):
+            file_ignorer = FileIgnorer(STEAMCMD_BOOTSTRAP_DIR,
+                {'metadata', '.ref', 'share'}
+            )
             shutil.copytree.copytree(
                 STEAMCMD_BOOTSTRAP_DIR,
                 steamcmd_install_dir,
                 symlinks=True,
-                ignore=steam_wrapper.FileIgnorer({'metadata', '.ref', 'share'},
-                dirs_exist_ok=True)
+                ignore=file_ignorer,
+                dirs_exist_ok=True
             )
         else:
             raise OSError("SteamCMD is not installed")


### PR DESCRIPTION
After previous refactoring with no more inner function there was one variable which was lost from scope. It must now be transferred as an object attribute. This partially reverts previous work.
