### PR TITLE
Add autoprune-unless to GL32 extensions

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -92,6 +92,7 @@ add-extensions:
     merge-dirs: *gl-merge-dirs
     download-if: active-gl-driver
     enable-if: active-gl-driver
+    autoprune-unless: active-gl-driver
 
   org.freedesktop.Platform.GL32.Debug:
     directory: lib/debug/lib/i386-linux-gnu/GL
@@ -101,6 +102,7 @@ add-extensions:
     no-autodownload: true
     merge-dirs: *gl-merge-dirs
     enable-if: active-gl-driver
+    autoprune-unless: active-gl-driver
 
   org.freedesktop.Platform.VAAPI.Intel.i386:
     directory: lib/i386-linux-gnu/dri/intel-vaapi-driver


### PR DESCRIPTION
This follows org.freedesktop.Platform's metadata in regards to GL extensions.

Closes: https://github.com/flathub/com.valvesoftware.Steam/issues/1138