### PR TITLE
Block `libtcmalloc_minimal.so.4` to avoid game crashes

### DIFF
--- a/resources/blocklist/day_of_defeat_source.yml
+++ b/resources/blocklist/day_of_defeat_source.yml
@@ -1,0 +1,8 @@
+entries:
+  - basedir: "*(/*|/.*)/Day of Defeat Source"
+    blocklists:
+      - binaries:
+          - path: hl2_linux
+            libdir: bin
+        libraries:
+          - path: libtcmalloc_minimal.so.4

--- a/resources/blocklist/fistful_of_frags.yml
+++ b/resources/blocklist/fistful_of_frags.yml
@@ -1,0 +1,8 @@
+entries:
+  - basedir: "*(/*|/.*)/Fistful of Frags/sdk"
+    blocklists:
+      - binaries:
+          - path: hl2_linux
+            libdir: bin
+        libraries:
+          - path: libtcmalloc_minimal.so.4

--- a/resources/blocklist/garrys_mod.yml
+++ b/resources/blocklist/garrys_mod.yml
@@ -1,0 +1,8 @@
+entries:
+  - basedir: "*(/*|/.*)/GarrysMod"
+    blocklists:
+      - binaries:
+          - path: hl2_linux
+            libdir: bin
+        libraries:
+          - path: libtcmalloc_minimal.so.4

--- a/resources/blocklist/no_more_room_in_hell.yml
+++ b/resources/blocklist/no_more_room_in_hell.yml
@@ -1,0 +1,8 @@
+entries:
+  - basedir: "*(/*|/.*)/nmrih"
+    blocklists:
+      - binaries:
+          - path: hl2_linux
+            libdir: bin
+        libraries:
+          - path: libtcmalloc_minimal.so.4

--- a/resources/blocklist/team_fortress2.yml
+++ b/resources/blocklist/team_fortress2.yml
@@ -1,0 +1,8 @@
+entries:
+  - basedir: "*(/*|/.*)/Team Fortress 2"
+    blocklists:
+      - binaries:
+          - path: hl2_linux
+            libdir: bin
+        libraries:
+          - path: libtcmalloc_minimal.so.4


### PR DESCRIPTION
Source games started to crash in their vendored versions of `libtcmalloc_minimal.so.4` after the Freedesktop SDK runtime was updated to `23.08`.

Falling back to the version built [in the app manifest](https://github.com/flathub/com.valvesoftware.Steam/blob/291612cb6767069517412f65818e099b58a610ae/modules-32bit.yml#L65-L80) seems to avoid the crash.

Closes: https://github.com/flathub/com.valvesoftware.Steam/issues/1158