### PR TITLE
Fix for more source 1 games by blocking libtcmalloc.minimal.so.4

### DIFF
--- a/resources/blocklist/black_mesa.yml
+++ b/resources/blocklist/black_mesa.yml
@@ -1,0 +1,8 @@
+entries:
+  - basedir: "*(/*|/.*)/Black Mesa"
+    blocklists:
+      - binaries:
+          - path: bms_linux
+            libdir: bin
+        libraries:
+          - path: libtcmalloc_minimal.so.4

--- a/resources/blocklist/counter_strike_source.yml
+++ b/resources/blocklist/counter_strike_source.yml
@@ -1,0 +1,8 @@
+entries:
+  - basedir: "*(/*|/.*)/Counter-Strike Source"
+    blocklists:
+      - binaries:
+          - path: hl2_linux
+            libdir: bin
+        libraries:
+          - path: libtcmalloc_minimal.so.4


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
this pr will fix more source 1 games like Counter Strike Source and Black Mesa
based on https://github.com/flathub/com.valvesoftware.Steam/pull/1171 