### PR TITLE
fix more source engine games that affected with malloc issue

### DIFF
--- a/resources/blocklist/entropy_zero_2.yml
+++ b/resources/blocklist/entropy_zero_2.yml
@@ -1,0 +1,8 @@
+entries:
+  - basedir: "*(/*|/.*)/EntropyZero2"
+    blocklists:
+      - binaries:
+          - path: hl2_linux
+            libdir: bin
+        libraries:
+          - path: libtcmalloc_minimal.so.4

--- a/resources/blocklist/hl2_dm.yml
+++ b/resources/blocklist/hl2_dm.yml
@@ -1,0 +1,8 @@
+entries:
+  - basedir: "*(/*|/.*)/Half-Life 2 Deathmatch"
+    blocklists:
+      - binaries:
+          - path: hl2_linux
+            libdir: bin
+        libraries:
+          - path: libtcmalloc_minimal.so.4

--- a/resources/blocklist/hls_dm.yml
+++ b/resources/blocklist/hls_dm.yml
@@ -1,0 +1,8 @@
+entries:
+  - basedir: "*(/*|/.*)/Half-Life 1 Source Deathmatch"
+    blocklists:
+      - binaries:
+          - path: hl2_linux
+            libdir: bin
+        libraries:
+          - path: libtcmalloc_minimal.so.4

--- a/resources/blocklist/portal_reloaded.yml
+++ b/resources/blocklist/portal_reloaded.yml
@@ -1,0 +1,8 @@
+entries:
+  - basedir: "*(/*|/.*)/Portal Reloaded"
+    blocklists:
+      - binaries:
+          - path: portal2_linux
+            libdir: bin
+        libraries:
+          - path: libtcmalloc_minimal.so.4

--- a/resources/blocklist/zombie_panic_source.yml
+++ b/resources/blocklist/zombie_panic_source.yml
@@ -1,0 +1,8 @@
+entries:
+  - basedir: "*(/*|/.*)/Zombie Panic Source"
+    blocklists:
+      - binaries:
+          - path: zps_linux
+            libdir: bin
+        libraries:
+          - path: libtcmalloc_minimal.so.4

--- a/resources/blocklist/zombie_panic_source.yml
+++ b/resources/blocklist/zombie_panic_source.yml
@@ -1,8 +1,0 @@
-entries:
-  - basedir: "*(/*|/.*)/Zombie Panic Source"
-    blocklists:
-      - binaries:
-          - path: zps_linux
-            libdir: bin
-        libraries:
-          - path: libtcmalloc_minimal.so.4


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
this pr will fix Portal Reloaded, Half Life 2 Deathmatch,Half Life Source Deathmatch,and Entropy Zero 2 by blocking libtcmalloc_minimal.so.4 