### PR TITLE
Add ownership to com.steampowered.PressureVessel.LaunchAlongsideSteam.*

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -30,6 +30,7 @@ finish-args:
   - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.freedesktop.PowerManagement
   - --talk-name=org.freedesktop.Notifications
+  - --own-name=com.steampowered.PressureVessel.LaunchAlongsideSteam.*
   - --filesystem=xdg-music:ro
   - --filesystem=xdg-pictures:ro
   - --filesystem=xdg-run/app/com.discordapp.Discord:create


### PR DESCRIPTION
Add ownership to com.steampowered.PressureVessel.LaunchAlongsideSteam.* to resolve errors found in issues.

Unable to acquire bus name "com.steampowered.PressureVessel.LaunchAlongsideSteam"
https://github.com/flathub/com.valvesoftware.Steam/issues/1168#issuecomment-1741710694

I have not tested building.

<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
