### PR TITLE
Fix parsing /.flatpak-info

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -171,3 +171,19 @@ modules:
       - -Dshared_library_guard_config=/app/etc/freedesktop-sdk.ld.so.blockedlist
     sources:
       - sources/shared-library-guard-git.json
+
+# -- pygobject, used by steam_wrapper --
+
+  - name: py3cairo
+    buildsystem: meson
+    sources:
+      - type: archive
+        url: https://github.com/pygobject/pycairo/archive/refs/tags/v1.25.1.tar.gz
+        sha256: fabe2a6ae082e7970084ce61b29087f2211f098a099b0d6de68caac4be1263fb
+        x-checker-data:
+          type: anitya
+          project-id: 13166
+          stable-only: true
+          url-template: https://github.com/pygobject/pycairo/archive/refs/tags/v$version.tar.gz
+
+# -- end pygobject --

--- a/python3-requirements.json
+++ b/python3-requirements.json
@@ -54,6 +54,20 @@
                     "sha256": "68c1a125cc49e343d535af2dd25074e9cb0908c6607f073947c4a04bbe234534"
                 }
             ]
+        },
+        {
+            "name": "python3-PyGObject",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"PyGObject\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/ac/4a/f24ddf1d20cc4b56affc7921e29928559a06c922eb60077448392792b914/PyGObject-3.46.0.tar.gz",
+                    "sha256": "481437b05af0a66b7c366ea052710eb3aacbb979d22d30b797f7ec29347ab1e6"
+                }
+            ]
         }
     ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 jsonschema
 PyYAML
 vdf
+PyGObject


### PR DESCRIPTION
The `/.flatpak-info` is a keyfile in the format described by the desktop-entry-spec.

It is *not* a format that the Python configparser module can correctly parse.

The most accessible and certainly correct implementation of this is GLib.Keyfile so I switched it to this.

<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
