### PR TITLE
use `id` instead of `app-id`

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -1,4 +1,4 @@
-app-id: com.valvesoftware.Steam
+id: com.valvesoftware.Steam
 runtime: org.freedesktop.Platform
 runtime-version: &runtime-version '23.08'
 x-gl-version: &gl-version '1.4'


### PR DESCRIPTION
`app-id` is deprecated

<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
