### PR TITLE
manifest: Allow owning bus names in com.steampowered.* namespace

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -22,6 +22,7 @@ finish-args:
   - --socket=x11
   - --socket=pulseaudio
   - --share=network
+  - --own-name=com.steampowered.*
   - --talk-name=org.gnome.SettingsDaemon.MediaKeys
   # Wine uses UDisks2 to enumerate disk drives
   - --system-talk-name=org.freedesktop.UDisks2


### PR DESCRIPTION
This is an alternative to flathub/com.valvesoftware.Steam#1200 and #1209. See also
https://github.com/flathub/com.valvesoftware.Steam/issues/1166#issuecomment-1742799353.

steampowered.com is a domain name owned by Valve and used to represent the Steam app-store as a whole.

Names in the `com.steampowered.PressureVessel.*` sub-namespace are by Steam's container runtime module (pressure-vessel) to give individual games access to Steam-wide functionality.

When certain developer/debug features are enabled, names of the form `com.steampowered.App*` are also used to allow processes in the trusted computing base to insert extra debugging commands into the per-game containers. It is not possible to match this namespace more precisely than `com.steampowered.*` in flatpak(1) or xdg-dbus-proxy(1) syntax, so we must use `com.steampowered.*` if we want to enable that feature.

Other `com.steampowered.*` names might be used in future for other Steam functionality, so allow the whole namespace.

Resolves: https://github.com/flathub/com.valvesoftware.Steam/issues/1166

---

Untested, but it's a simple change. This is what I have in my `flatpak override --user` on machines where I test the Steam Runtime.

I've opened a separate MR #1209 for the narrower version that @nanonyme suggested, where all of `com.steampowered.PressureVessel.*` is allowed but `com.steampowered.App123` is not.