### PR TITLE
manifest: Allow owning bus names in com.steampowered.PressureVessel.*

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -22,6 +22,7 @@ finish-args:
   - --socket=x11
   - --socket=pulseaudio
   - --share=network
+  - --own-name=com.steampowered.PressureVessel.*
   - --talk-name=org.gnome.SettingsDaemon.MediaKeys
   # Wine uses UDisks2 to enumerate disk drives
   - --system-talk-name=org.freedesktop.UDisks2


### PR DESCRIPTION
This is an alternative to flathub/com.valvesoftware.Steam#1200 and #1208. See also
https://github.com/flathub/com.valvesoftware.Steam/issues/1166#issuecomment-1742799353.

steampowered.com is a domain name owned by Valve and used to represent the Steam app-store as a whole.

Names in the `com.steampowered.PressureVessel.*` sub-namespace are by Steam's container runtime module (pressure-vessel) to give individual games access to Steam-wide functionality.

When certain developer/debug features are enabled, names of the form `com.steampowered.App*` are also used to allow processes in the trusted computing base to insert extra debugging commands into the per-game containers. It is not possible to match this namespace more precisely than `com.steampowered.*` in flatpak(1) or xdg-dbus-proxy(1) syntax, so we must use `com.steampowered.*` if we want to enable that feature.

This particular PR *does not* do that, and instead limits Steam's bus name access to the names that it uses unconditionally; it might need to be extended in future, if more Steam features move from ad-hoc Steam-specific IPC mechanisms to D-Bus.

Resolves: https://github.com/flathub/com.valvesoftware.Steam/issues/1166

---

I would recommend #1208 in preference to this, but if app maintainers are uncomfortable with #1208, then this is better than #1200.