### PR TITLE
Update shared-library-guard to v24.01.1

### DIFF
--- a/modules-32bit.yml
+++ b/modules-32bit.yml
@@ -81,7 +81,6 @@ modules:
       arch:
         x86_64: *compat_i386_opts
     buildsystem: meson
-    subdir: shared-library-guard
     config-opts:
       - -Dshared_library_guard_config=/app/etc/freedesktop-sdk.ld.so.blockedlist
     sources:

--- a/modules.yml
+++ b/modules.yml
@@ -163,7 +163,6 @@ modules:
 
   - name: shared-library-guard
     buildsystem: meson
-    subdir: shared-library-guard
     config-opts:
       - -Dshared_library_guard_config=/app/etc/freedesktop-sdk.ld.so.blockedlist
     sources:

--- a/sources/shared-library-guard-git.json
+++ b/sources/shared-library-guard-git.json
@@ -1,6 +1,6 @@
 {
     "type": "git",
     "url": "https://gitlab.com/freedesktop-sdk/shared-library-guard",
-    "commit": "40e5754de97b65df60db39ac11a7691d3de35fb7",
-    "tag": "v21.05.1"
+    "commit": "6a5bf18c654e15c5290920720743b36655fa87c1",
+    "tag": "v24.01.1"
 }


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
In latest release there is no more subdir so creating manual pull request to avoid auto-updater remaining broken.