### PR TITLE
Officially require Flatpak 1.12.x

### DIFF
--- a/com.valvesoftware.Steam.metainfo.xml
+++ b/com.valvesoftware.Steam.metainfo.xml
@@ -13,7 +13,6 @@
     <p>Note: This is a community package of Steam gaming plaform not officially supported by Valve. Report bugs through linked issue tracker.</p>
     <p>Note: To add a game library on another drive, first you need to grant the app access to it:</p>
     <p>flatpak override --user --filesystem=/path/to/your/Steam/Library com.valvesoftware.Steam</p>
-    <p>Note: You need Flatpak version 1.12 or later to be able to run Proton 5.13 and newer.</p>
     <p xml:lang="pt_BR">Este é um pacote de comunidade da plataforma de jogos Steam não oficialmente suportada pela Valve. Relate bugs por meio do rastreador de problemas vinculado.</p>
     <p xml:lang="pt_BR">O Steam é uma plataforma popular para comprar, baixar e jogar jogos e conversar com outros jogadores. </p>
     <p xml:lang="pt_BR">Muitos jogos exigem uma compra online, mas alguns jogos populares, como o Team Fortress 2, são gratuitos. Ao pesquisar na loja, certifique-se de restringir os resultados pelo sistema operacional SteamOS/Linux. Nem todos os jogos Linux são compatíveis com o seu sistema, portanto, verifique os requisitos antes de comprar jogos.</p>

--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -70,7 +70,7 @@ finish-args:
   - --env=XDG_CONFIG_DIRS=/etc/xdg:/usr/lib/x86_64-linux-gnu/GL:/usr/lib/i386-linux-gnu/GL
   - --env=XDG_DATA_DIRS=/app/share:/usr/lib/extensions/vulkan/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share
   - --env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/app/lib32/gstreamer-1.0:/usr/lib/extensions/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0:/usr/lib/i386-linux-gnu/gstreamer-1.0
-  - --require-version=1.11.1
+  - --require-version=1.12.0
 
 add-extensions:
   org.freedesktop.Platform.Compat.i386:


### PR DESCRIPTION
* manifest: Bump required Flatpak version to 1.12.x
    
    The 1.11.x series were development snapshots which should only be used
    by developers and early adopters. They ceased to be security-supported
    with the release of Flatpak 1.12.0 in 2021, and we should not encourage
    their use.
    
    Newer releases in the 1.12.x branch are available and are strongly
    recommended (they fix security vulnerabilities, as well as non-security
    issues), but don't enforce use of those here, since distributions with
    particularly change-averse policies might have backported a subset of
    those fixes into 1.12.0.
    
    Related to #1239.

* metainfo: Remove a note about needing Flatpak 1.12 for Proton
    
    Flatpak 1.12 is now necessary to run Steam *at all*, so it's no longer
    necessary to call this out as a special requirement for Proton.
    
    Related to #1239.

---

cc @barthalion 