### PR TITLE
Add pressure-vessel's overrides data dir to XDG_DATA_DIRS

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -68,7 +68,7 @@ finish-args:
   - --env=PYTHONPATH=/app/utils/lib/python3.10/site-packages
   - --env=PROTON_DEBUG_DIR=/var/tmp
   - --env=XDG_CONFIG_DIRS=/etc/xdg:/usr/lib/x86_64-linux-gnu/GL:/usr/lib/i386-linux-gnu/GL
-  - --env=XDG_DATA_DIRS=/app/share:/usr/lib/extensions/vulkan/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share
+  - --env=XDG_DATA_DIRS=/app/share:/usr/lib/extensions/vulkan/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share:/usr/lib/pressure-vessel/overrides/share
   - --env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/app/lib32/gstreamer-1.0:/usr/lib/extensions/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0:/usr/lib/i386-linux-gnu/gstreamer-1.0
   - --require-version=1.12.0
 


### PR DESCRIPTION
This is a hack until the underlying issue is fixed in the steam-runtime. Pressure-vessel mounts Flatpak extensions on a different path within the container, and that breaks Vulkan Layers due to that path not being in Vulkan-Loader's search paths, documented on: https://github.com/KhronosGroup/Vulkan-Loader/blob/main/docs/LoaderLayerInterface.md#linux-layer-discovery

This directory doesn't exist outside a pressure-vessel container, which is only used by games and not by all of them. But still, adding it to XDG_DATA_DIRS in finish-args shouldn't cause any adverse effect, as these search paths are not required to be all valid.

fixes #1280
related to ValveSoftware/steam-runtime#662

<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
