### PR TITLE
Add blocklist for Zombie Panic: Source

### DIFF
--- a/resources/blocklist/zombie_panic_source.yml
+++ b/resources/blocklist/zombie_panic_source.yml
@@ -1,0 +1,8 @@
+entries:
+  - basedir: "*(/*|/.*)/Zombie Panic Source"
+    blocklists:
+      - binaries:
+          - path: zps_linux
+            libdir: bin
+        libraries:
+          - path: libtcmalloc_minimal.so.4


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->
This PR will fix Zombie Panic: Source (yet another Source Engine game) by blocking libtcmalloc_minimal.so.4

Based on the works of @dreamyukii (https://github.com/flathub/com.valvesoftware.Steam/pull/1189)