### PR TITLE
Include zlib-ng to improve performance

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -3,6 +3,20 @@ buildsystem: simple
 build-commands: []
 modules:
 
+  - name: zlib-ng
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DZLIB_ENABLE_TESTS=false
+      - -DZLIB_COMPAT=true
+    sources:
+      - type: archive
+        url: https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.2.3.tar.gz
+        sha256: f2fb245c35082fe9ea7a22b332730f63cf1d42f04d84fe48294207d033cba4dd
+        x-checker-data:
+          type: anitya
+          project-id: 115592
+          url-template: https://github.com/zlib-ng/zlib-ng/archive/refs/tags/$version.tar.gz
+          
 # -- controllers --
 
   - name: hwdata


### PR DESCRIPTION
Include zlib-ng with compatibility options. Ideally, this would make benchmarks with the Flathub version of Steam perform better.

---

For reference, distributions like Fedora already use zlib-ng so that their applications are more optimised on newer hardware. By also applying this change to this package, games might perform a little faster on hardware that supports advanced instructions.

Details about Fedora's migration:

- https://fedoraproject.org/wiki/Changes/ZlibNGTransition

Details about Zlib-ng:

- https://github.com/zlib-ng/zlib-ng

Similar discussion for the FreeDesktop SDK:

- https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1731
