### PR TITLE
Access only to dri and input

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -35,7 +35,8 @@ finish-args:
   - --filesystem=xdg-music:ro
   - --filesystem=xdg-pictures:ro
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
-  - --device=all
+  - --device=dri
+  - --device=input
   - --allow=multiarch
   - --allow=devel
   - --allow=bluetooth


### PR DESCRIPTION
Since there is ```--device=input``` option includes game controllers  (see https://github.com/flatpak/flatpak/pull/5481), I think we have no reason to give all devices access to Steam. This PR only gives access ```dri``` and ```input``` to Steam.