### PR TITLE
steam not working, wrapper.py error

### DIFF
--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -107,7 +107,7 @@ def keyfile_get_string_dict(keyfile, section, key):
         return {}
 
 
-def read_flatpak_info():
+def read_flatpak_info(path=FLATPAK_INFO):
     flatpak_info = GLib.KeyFile.new()
     assert flatpak_info.load_from_file(FLATPAK_INFO, GLib.KeyFileFlags.NONE)
 
@@ -471,7 +471,7 @@ def main(steam_binary=STEAM_PATH):
     argv = [sys.argv[0], '-no-cef-sandbox'] + sys.argv[1:]
     logging.basicConfig(level=logging.DEBUG)
     logging.info(WIKI_URL)
-    current_info = read_flatpak_info()
+    current_info = read_flatpak_info("/.flatpak-info")
     check_allowed_to_run(current_info)
     check_extensions(current_info)
     should_update_symlinks = env_is_true(os.environ.get("FLATPAK_STEAM_UPDATE_SYMLINKS", "0"))

--- a/steam_wrapper/steam_wrapper.py
+++ b/steam_wrapper/steam_wrapper.py
@@ -109,7 +109,8 @@ def keyfile_get_string_dict(keyfile, section, key):
 
 def read_flatpak_info(path=FLATPAK_INFO):
     flatpak_info = GLib.KeyFile.new()
-    assert flatpak_info.load_from_file(FLATPAK_INFO, GLib.KeyFileFlags.NONE)
+    if not flatpak_info.load_from_file(path, GLib.KeyFileFlags.NONE):
+        raise RuntimeError(f"Cannot load flatpak info from {path}")
 
     try:
         filesystems = flatpak_info.get_string_list("Context", "filesystems")


### PR DESCRIPTION
just testing again a build that was closed pull request from [here](https://github.com/flathub/com.valvesoftware.Steam/pull/1434/#issue-3240635822)
regarding issue: https://github.com/flathub/com.valvesoftware.Steam/issues/1402
trying to fix this error when running or downloading steam via flatpak:
```
$ flatpak run com.valvesoftware.Steam 

Traceback (most recent call last):
  File "/app/bin/steam", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/app/lib/python3.12/site-packages/steam_wrapper.py", line 474, in main
    current_info = read_flatpak_info()
                   ^^^^^^^^^^^^^^^^^^^
  File "/app/lib/python3.12/site-packages/steam_wrapper.py", line 120, in read_flatpak_info
    "flatpak-version": flatpak_info.get_string("Instance", "flatpak-version"),
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gi.repository.GLib.GError: g-key-file-error-quark: Key file does not have group [Instance]
```
the problem was python code of steam couldn't get the .flatpak-info so i rearranged it.
