### PR TITLE
feat: restore execution on discrete gpu

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -190,8 +190,6 @@ modules:
       - |
         set -e
         sed -i s:/usr/bin/steam:/app/bin/steam: steam.desktop
-        desktop-file-edit --remove-key=PrefersNonDefaultGPU steam.desktop
-        desktop-file-edit --remove-key=X-KDE-RunOnDiscreteGpu steam.desktop
         desktop-file-edit --set-key=StartupWMClass --set-value=Steam steam.desktop
         sed -i s:/usr/lib/:/app/lib/: steam
         PREFIX=/app make install


### PR DESCRIPTION
<!-- If this pull request updates Steam bootstrapper or steamcmd, the relevant commits must contain the updated version number of said components. -->


Steam running on discrete GPU , on Asus tuf gaming f15.

NVIDIA GeForce RTX™ 4070 Laptop GPU
Fedora Linux 43 (Workstation Edition)
Wayland
Gnome 49
Linux 6.17.12-300.fc43.x86_64


Nvidia proprietary driver: 580.119.02

<img width="817" height="320" alt="image" src="https://github.com/user-attachments/assets/f68cf2bf-2945-4770-9443-13e1a1a82a00" />


<img width="1703" height="1030" alt="image" src="https://github.com/user-attachments/assets/41ddee64-b4e1-484d-a42c-4d41736ac97c" />
