### PR TITLE
Add MangoHud configuration to filesystem arguments

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -36,6 +36,7 @@ finish-args:
   - --filesystem=xdg-pictures:ro
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --filesystem=xdg-run/pipewire-0:ro
+  - --filesystem=xdg-config/MangoHud:ro
   - --device=all
   - --allow=multiarch
   - --allow=devel


### PR DESCRIPTION
steam contains it's own mangohud defaults.  This change allows the user's preferences to be used.  So tools like [mango juice](https://flathub.org/en/apps/io.github.radiolamp.mangojuice) can work.

