### PR TITLE
Add to STEAM_EXTRA_COMPAT_TOOLS_PATHS environment variable

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -71,7 +71,7 @@ finish-args:
   - --unset-env=SDL_VIDEODRIVER
   - --env=DBUS_FATAL_WARNINGS=0
   - --env=SSL_CERT_DIR=/etc/ssl/certs
-  - --env=STEAM_EXTRA_COMPAT_TOOLS_PATHS=/app/share/steam/compatibilitytools.d:/app/utils/share/steam/compatibilitytools.d
+  - --env=STEAM_EXTRA_COMPAT_TOOLS_PATHS=/app/share/steam/compatibilitytools.d:/app/utils/share/steam/compatibilitytools.d:/run/parent/app/share/steam/compatibilitytools.d
   - --env=PATH=/app/bin:/app/utils/bin:/usr/bin
   - --env=PYTHONPATH=/app/utils/lib/python3.13/site-packages
   - --env=PROTON_DEBUG_DIR=/var/tmp


### PR DESCRIPTION
Adding this path in conjunction with SteamRT3, will allow https://github.com/flathub/com.valvesoftware.Steam.CompatibilityTool.Proton-GE to remove the toolmanifest.patch that opts out of being wrapped by another Steam Compatibility Tool, and causes most of the issues users have.