### PR TITLE
Grant system-bus access to org.freedesktop.NetworkManager

### DIFF
--- a/com.valvesoftware.Steam.yml
+++ b/com.valvesoftware.Steam.yml
@@ -28,6 +28,8 @@ finish-args:
   - --system-talk-name=org.freedesktop.UDisks2
   - --talk-name=org.kde.StatusNotifierWatcher
   - --system-talk-name=org.freedesktop.UPower
+  # Big Picture Mode queries NetworkManager over the system bus for connectivity status
+  - --system-talk-name=org.freedesktop.NetworkManager
   - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.gnome.SessionManager
   - --talk-name=org.freedesktop.PowerManagement


### PR DESCRIPTION
Big Picture Mode queries NetworkManager over the system bus to display connectivity status. Without this permission, the D-Bus call is denied by the sandbox and BPM's network status (the 'wifi' icon in the title/status bar) is broken for every Flatpak Steam user.

